### PR TITLE
Add local Lua extension editing support

### DIFF
--- a/app/src/main/java/my/noveldokusha/ExtensionRepository.kt
+++ b/app/src/main/java/my/noveldokusha/ExtensionRepository.kt
@@ -43,13 +43,13 @@ class ExtensionRepository @Inject constructor(
 
     override suspend fun installExtensionFromInfo(id: String, name: String, version: String, language: String, imageUrl: String?, codeUrl: String?) {
         try {
-            // codeUrl должен быть передан из YAML конфигурации
-            val finalCodeUrl = codeUrl ?: throw IllegalArgumentException("codeUrl is required")
-
-            // Используем YAML для settings
-            val settingsYaml = """
-                codeUrl: $finalCodeUrl
-            """.trimIndent()
+            val settingsYaml = buildString {
+                if (!codeUrl.isNullOrBlank()) {
+                    appendLine("codeUrl: $codeUrl")
+                } else {
+                    appendLine("sourceType: local")
+                }
+            }.trim()
 
             val dbExtension = my.noveldokusha.feature.local_database.tables.Extension(
                 id = id,
@@ -62,11 +62,11 @@ class ExtensionRepository @Inject constructor(
                 enabled = true,
                 installed = true,
                 chapterType = "HTML",
-                settings = settingsYaml
+                settings = settingsYaml.ifBlank { "{}" }
             )
             extensionDao.insert(dbExtension)
 
-            Timber.d("Extension installed in database: $name with codeUrl: $finalCodeUrl")
+            Timber.d("Extension installed in database: $name")
         } catch (e: Exception) {
             Timber.e(e, "Failed to install extension: $name")
             throw e

--- a/app/src/main/java/my/noveldokusha/LuaSourceProviderImpl.kt
+++ b/app/src/main/java/my/noveldokusha/LuaSourceProviderImpl.kt
@@ -42,10 +42,10 @@ class LuaSourceProviderImpl @Inject constructor(
             if (cached.isNotEmpty()) {
                 _sourcesFlow.value = cached
             }
-            reload()
+            reloadInternal()
             @OptIn(kotlinx.coroutines.FlowPreview::class)
             extensionRepository.getInstalledExtensionsFlow().debounce(500).collect {
-                reload()
+                reloadInternal()
             }
         }
     }
@@ -91,7 +91,11 @@ class LuaSourceProviderImpl @Inject constructor(
         }
     }
 
-    private suspend fun reload() {
+    override suspend fun reload() {
+        reloadInternal()
+    }
+
+    private suspend fun reloadInternal() {
         try {
             luaSourceLoader.loadAllSources()
                 .onSuccess { sources ->

--- a/core/src/main/java/my/noveldokusha/core/ExtensionManager.kt
+++ b/core/src/main/java/my/noveldokusha/core/ExtensionManager.kt
@@ -35,5 +35,7 @@ interface ExtensionManager {
 
     suspend fun updateExtensionSettings(extensionId: String, settings: String)
 
+    suspend fun getExtensionSettings(extensionId: String): String?
+
     suspend fun isExtensionInstalled(extensionId: String): Boolean
 }

--- a/features/extensions/src/main/java/my/noveldokusha/extensions/ExtensionsManagerViewModel.kt
+++ b/features/extensions/src/main/java/my/noveldokusha/extensions/ExtensionsManagerViewModel.kt
@@ -16,6 +16,7 @@ import my.noveldokusha.core.appPreferences.AppPreferences
 import my.noveldokusha.core.appPreferences.ExtensionInfoCached
 import my.noveldokusha.network.NetworkClient
 import my.noveldokusha.scraper.LuaSourceLoader
+import my.noveldokusha.scraper.LuaSourceProvider
 import my.noveldokusha.data.ScraperRepository
 import org.yaml.snakeyaml.Yaml
 import timber.log.Timber
@@ -29,6 +30,7 @@ class ExtensionsManagerViewModel @Inject constructor(
     private val appPreferences: AppPreferences,
     private val scraperRepository: ScraperRepository,
     private val luaSourceLoader: LuaSourceLoader,          // ← для скачивания .lua
+    private val luaSourceProvider: LuaSourceProvider,
 ) : ViewModel() {
 
     private val yaml = Yaml()
@@ -78,6 +80,162 @@ class ExtensionsManagerViewModel @Inject constructor(
         ExtensionsScreenEvent.OnBackPressed              -> Unit
         is ExtensionsScreenEvent.OnExtensionInstall      -> installExtension(event.extensionId)
         is ExtensionsScreenEvent.OnExtensionUninstallById -> uninstallExtensionById(event.extensionId)
+        ExtensionsScreenEvent.OnImportLuaClick            -> Unit
+        is ExtensionsScreenEvent.OnEditLuaClick           -> openLuaEditor(event.extensionId)
+        ExtensionsScreenEvent.OnLuaEditorDismiss          -> closeLuaEditor()
+        is ExtensionsScreenEvent.OnLuaEditorChange        -> updateLuaEditorText(event.code)
+        ExtensionsScreenEvent.OnLuaEditorSave             -> saveLuaEditor()
+        is ExtensionsScreenEvent.OnResetLuaClick          -> resetLuaExtension(event.extensionId)
+        is ExtensionsScreenEvent.OnDeleteLocalLuaClick    -> deleteLocalExtension(event.extensionId)
+        ExtensionsScreenEvent.OnClearAllLocalLuaClick     -> clearAllLocalExtensions()
+    }
+
+
+    // ── Локальный импорт / редактор Lua ─────────────────────────────────────
+
+    private fun luaField(code: String, key: String, fallback: String = ""): String {
+        val regex = Regex("""(?m)^\s*$key\s*=\s*["']([^"']+)["']""")
+        return regex.find(code)?.groupValues?.getOrNull(1)?.trim().orEmpty().ifBlank { fallback }
+    }
+
+    private suspend fun settingsMap(extensionId: String): Map<String, Any>? {
+        val raw = extensionManager.getExtensionSettings(extensionId) ?: return null
+        if (raw.isBlank() || raw == "{}") return null
+        return try {
+            @Suppress("UNCHECKED_CAST")
+            yaml.loadAs(raw, Map::class.java) as? Map<String, Any>
+        } catch (e: Exception) {
+            Timber.w(e, "Bad settings YAML for $extensionId")
+            null
+        }
+    }
+
+    private suspend fun isLocalExtension(extensionId: String): Boolean =
+        settingsMap(extensionId)?.get("sourceType")?.toString() == "local"
+
+    private suspend fun getCodeUrl(extensionId: String): String? =
+        settingsMap(extensionId)?.get("codeUrl")?.toString()
+
+    fun openLuaEditor(extensionId: String) = viewModelScope.launch {
+        val ext = _state.value.extensions.find { it.id == extensionId } ?: return@launch
+        val code = luaSourceLoader.readScript(extensionId).orEmpty()
+
+        _state.update {
+            it.copy(
+                showLuaEditor = true,
+                luaEditorExtensionId = extensionId,
+                luaEditorTitle = ext.name,
+                luaEditorCode = code,
+                luaEditorError = null
+            )
+        }
+    }
+
+    fun updateLuaEditorText(code: String) {
+        _state.update { it.copy(luaEditorCode = code, luaEditorError = null) }
+    }
+
+    fun closeLuaEditor() {
+        _state.update {
+            it.copy(
+                showLuaEditor = false,
+                luaEditorExtensionId = null,
+                luaEditorTitle = "",
+                luaEditorCode = "",
+                luaEditorError = null
+            )
+        }
+    }
+
+    fun saveLuaEditor() = viewModelScope.launch {
+        val id = _state.value.luaEditorExtensionId ?: return@launch
+        val code = _state.value.luaEditorCode
+
+        if (luaSourceLoader.validateScript(code, "$id.lua").isFailure) {
+            _state.update { it.copy(luaEditorError = "Lua compile error") }
+            return@launch
+        }
+
+        if (!luaSourceLoader.saveScript(id, code)) {
+            _state.update { it.copy(luaEditorError = "Failed to save Lua file") }
+            return@launch
+        }
+
+        luaSourceProvider.reload()
+        closeLuaEditor()
+    }
+
+    fun importLuaFromText(fileName: String, code: String) = viewModelScope.launch {
+        if (luaSourceLoader.validateScript(code, fileName).isFailure) {
+            _state.update { it.copy(error = "Lua compile error") }
+            return@launch
+        }
+
+        val fallbackId = fileName.substringBeforeLast('.').ifBlank { "local_source" }
+        val id = luaField(code, "id", fallbackId).replace(Regex("[^A-Za-z0-9_.-]"), "_")
+        val name = luaField(code, "name", id)
+        val version = luaField(code, "version", "1.0.0")
+        val language = luaField(code, "language", "en")
+        val icon = luaField(code, "icon")
+
+        if (!luaSourceLoader.saveScript(id, code)) {
+            _state.update { it.copy(error = "Failed to save imported Lua file") }
+            return@launch
+        }
+
+        extensionManager.installExtensionFromInfo(
+            id = id,
+            name = name,
+            version = version,
+            language = language,
+            imageUrl = icon.ifBlank { null },
+            codeUrl = null
+        )
+        extensionManager.updateExtensionSettings(id, "sourceType: local")
+        luaSourceProvider.reload()
+    }
+
+    fun resetLuaExtension(extensionId: String) = viewModelScope.launch {
+        val codeUrl = getCodeUrl(extensionId)
+
+        if (codeUrl.isNullOrBlank()) {
+            luaSourceLoader.removeScript(extensionId)
+            if (isLocalExtension(extensionId)) {
+                extensionManager.uninstallExtension(extensionId)
+            }
+            luaSourceProvider.reload()
+            return@launch
+        }
+
+        luaSourceLoader.removeScript(extensionId)
+
+        if (!luaSourceLoader.downloadAndCacheScript(extensionId, codeUrl)) {
+            _state.update { it.copy(error = "Failed to restore repository Lua") }
+            return@launch
+        }
+
+        luaSourceProvider.reload()
+    }
+
+    fun deleteLocalExtension(extensionId: String) = viewModelScope.launch {
+        luaSourceLoader.removeScript(extensionId)
+        if (isLocalExtension(extensionId)) {
+            extensionManager.uninstallExtension(extensionId)
+        }
+        luaSourceProvider.reload()
+    }
+
+    fun clearAllLocalExtensions() = viewModelScope.launch {
+        val localIds = extensionManager.getInstalledExtensions()
+            .map { it.id }
+            .filter { isLocalExtension(it) }
+
+        localIds.forEach { id ->
+            luaSourceLoader.removeScript(id)
+            extensionManager.uninstallExtension(id)
+        }
+
+        luaSourceProvider.reload()
     }
 
     // ── Загрузка доступных расширений из репозитория ─────────────────────────

--- a/features/extensions/src/main/java/my/noveldokusha/extensions/ExtensionsScreen.kt
+++ b/features/extensions/src/main/java/my/noveldokusha/extensions/ExtensionsScreen.kt
@@ -1,5 +1,7 @@
 package my.noveldokusha.extensions
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -53,6 +55,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -104,6 +107,18 @@ private fun UnifiedExtensionsScreen(
     @Suppress("UNUSED_PARAMETER") onExtensionsLanguageFilterDismiss: () -> Unit = {},
     @Suppress("UNUSED_PARAMETER") onRefresh: (() -> Unit)? = null
 ) {
+    val context = LocalContext.current
+    val importLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            val code = input.bufferedReader().readText()
+            val fileName = uri.lastPathSegment?.substringAfterLast('/') ?: "local.lua"
+            viewModel.importLuaFromText(fileName, code)
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -149,10 +164,29 @@ private fun UnifiedExtensionsScreen(
                     state.availableExtensions.filter { it.language in state.selectedLanguages }
                 }
 
-                val installedExtensions = filteredExtensions.filter { it.isInstalled }
+                val availableIds = state.availableExtensions.map { it.id }.toSet()
+                val localInstalledExtensions = state.extensions
+                    .filter { installed -> installed.id !in availableIds }
+                    .filter { installed -> state.selectedLanguages.isEmpty() || installed.language in state.selectedLanguages }
+                    .map { installed ->
+                        ExtensionInfo(
+                            id = installed.id,
+                            name = installed.name,
+                            description = "Local Lua extension",
+                            author = "Local",
+                            version = installed.version,
+                            remoteVersion = installed.version,
+                            codeUrl = "",
+                            iconUrl = installed.iconUrl.orEmpty(),
+                            language = installed.language,
+                            isInstalled = true,
+                            isEnabled = installed.enabled
+                        )
+                    }
+                val installedExtensions = filteredExtensions.filter { it.isInstalled } + localInstalledExtensions
                 val availableExtensions = filteredExtensions.filter { !it.isInstalled }
 
-                if (filteredExtensions.isEmpty()) {
+                if (filteredExtensions.isEmpty() && localInstalledExtensions.isEmpty()) {
                     Box(
                         modifier = Modifier.fillMaxWidth(),
                         contentAlignment = Alignment.Center
@@ -167,6 +201,14 @@ private fun UnifiedExtensionsScreen(
                                 textAlign = TextAlign.Center
                             )
                             FilledTonalButton(
+                                onClick = { importLauncher.launch(arrayOf("text/*", "application/octet-stream", "application/x-lua")) },
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Icon(Icons.Default.Add, contentDescription = null)
+                                Spacer(modifier = Modifier.size(8.dp))
+                                Text("Import Lua")
+                            }
+                            FilledTonalButton(
                                 onClick = { viewModel.onEvent(ExtensionsScreenEvent.OnRefresh) },
                                 modifier = Modifier.fillMaxWidth()
                             ) {
@@ -180,6 +222,19 @@ private fun UnifiedExtensionsScreen(
                             .fillMaxWidth(),
                         contentPadding = PaddingValues(bottom = 300.dp),
                     ) {
+                        item {
+                            FilledTonalButton(
+                                onClick = { importLauncher.launch(arrayOf("text/*", "application/octet-stream", "application/x-lua")) },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp)
+                            ) {
+                                Icon(Icons.Default.Add, contentDescription = null)
+                                Spacer(modifier = Modifier.size(8.dp))
+                                Text("Import Lua")
+                            }
+                        }
+
                         if (installedExtensions.isNotEmpty()) {
                             item {
                                 Text(
@@ -230,6 +285,17 @@ private fun UnifiedExtensionsScreen(
         RepositoryUrlDialog(
             state = state,
             viewModel = viewModel
+        )
+    }
+
+    if (state.showLuaEditor) {
+        LuaEditorDialog(
+            title = state.luaEditorTitle,
+            code = state.luaEditorCode,
+            error = state.luaEditorError,
+            onCodeChange = { viewModel.onEvent(ExtensionsScreenEvent.OnLuaEditorChange(it)) },
+            onDismiss = { viewModel.onEvent(ExtensionsScreenEvent.OnLuaEditorDismiss) },
+            onSave = { viewModel.onEvent(ExtensionsScreenEvent.OnLuaEditorSave) }
         )
     }
 }
@@ -447,19 +513,35 @@ private fun ExtensionListItem(
                     }
                 }
                 extension.isInstalled -> {
-                    FilledTonalButton(
-                        onClick = {
-                            viewModel.onEvent(ExtensionsScreenEvent.OnExtensionUninstallById(extension.id))
-                        },
-                        modifier = Modifier.height(40.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Delete,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp)
-                        )
-                        Spacer(modifier = Modifier.size(6.dp))
-                        Text("Uninstall")
+                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        FilledTonalButton(
+                            onClick = { viewModel.onEvent(ExtensionsScreenEvent.OnEditLuaClick(extension.id)) },
+                            modifier = Modifier.height(40.dp)
+                        ) {
+                            Text("Edit Lua")
+                        }
+                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                            OutlinedButton(
+                                onClick = { viewModel.onEvent(ExtensionsScreenEvent.OnResetLuaClick(extension.id)) },
+                                modifier = Modifier.height(40.dp)
+                            ) {
+                                Text("Reset")
+                            }
+                            FilledTonalButton(
+                                onClick = {
+                                    viewModel.onEvent(ExtensionsScreenEvent.OnExtensionUninstallById(extension.id))
+                                },
+                                modifier = Modifier.height(40.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Filled.Delete,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                                Spacer(modifier = Modifier.size(6.dp))
+                                Text("Uninstall")
+                            }
+                        }
                     }
                 }
                 else -> {

--- a/features/extensions/src/main/java/my/noveldokusha/extensions/ExtensionsScreenState.kt
+++ b/features/extensions/src/main/java/my/noveldokusha/extensions/ExtensionsScreenState.kt
@@ -13,6 +13,11 @@ data class ExtensionsScreenState(
     val error: String? = null,
     val showRepositoryDialog: Boolean = false,
     val repositoryUrl: String = "https://raw.githubusercontent.com/HnDK0/external-sources/refs/heads/main/index.yaml",
+    val showLuaEditor: Boolean = false,
+    val luaEditorExtensionId: String? = null,
+    val luaEditorTitle: String = "",
+    val luaEditorCode: String = "",
+    val luaEditorError: String? = null,
 )
 
 @Immutable
@@ -55,4 +60,12 @@ sealed interface ExtensionsScreenEvent {
     data object OnBackPressed : ExtensionsScreenEvent // New event for back navigation
     data class OnExtensionInstall(val extensionId: String) : ExtensionsScreenEvent
     data class OnExtensionUninstallById(val extensionId: String) : ExtensionsScreenEvent
+    data object OnImportLuaClick : ExtensionsScreenEvent
+    data class OnEditLuaClick(val extensionId: String) : ExtensionsScreenEvent
+    data object OnLuaEditorDismiss : ExtensionsScreenEvent
+    data class OnLuaEditorChange(val code: String) : ExtensionsScreenEvent
+    data object OnLuaEditorSave : ExtensionsScreenEvent
+    data class OnResetLuaClick(val extensionId: String) : ExtensionsScreenEvent
+    data class OnDeleteLocalLuaClick(val extensionId: String) : ExtensionsScreenEvent
+    data object OnClearAllLocalLuaClick : ExtensionsScreenEvent
 }

--- a/features/extensions/src/main/java/my/noveldokusha/extensions/LuaEditorDialog.kt
+++ b/features/extensions/src/main/java/my/noveldokusha/extensions/LuaEditorDialog.kt
@@ -1,0 +1,62 @@
+package my.noveldokusha.extensions
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LuaEditorDialog(
+    title: String,
+    code: String,
+    error: String?,
+    onCodeChange: (String) -> Unit,
+    onDismiss: () -> Unit,
+    onSave: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+            ) {
+                if (!error.isNullOrBlank()) {
+                    Text(
+                        text = error,
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    )
+                }
+
+                OutlinedTextField(
+                    value = code,
+                    onValueChange = onCodeChange,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 280.dp),
+                    textStyle = TextStyle(fontFamily = FontFamily.Monospace),
+                    maxLines = Int.MAX_VALUE
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onSave) { Text("Save") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}

--- a/scraper/src/main/java/my/noveldokusha/scraper/LuaSourceLoader.kt
+++ b/scraper/src/main/java/my/noveldokusha/scraper/LuaSourceLoader.kt
@@ -685,6 +685,33 @@ class LuaSourceLoader @Inject constructor(
 
     fun clearCache() { cache.clear(); Timber.d("Lua source cache cleared") }
 
+    fun scriptFile(id: String): File = luaFile(id)
+
+    fun hasScript(id: String): Boolean = scriptFile(id).exists()
+
+    fun readScript(id: String): String? = scriptFile(id)
+        .takeIf { it.exists() }
+        ?.readText(Charsets.UTF_8)
+
+    suspend fun saveScript(id: String, code: String): Boolean = withContext(Dispatchers.IO) {
+        runCatching {
+            scriptFile(id).writeText(code, Charsets.UTF_8)
+            cache.remove(id)
+            Timber.d("Saved $id.lua")
+            true
+        }.getOrElse { e ->
+            Timber.e(e, "saveScript failed for $id")
+            false
+        }
+    }
+
+    suspend fun validateScript(code: String, fileName: String = "local.lua"): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            luaEngine.loadFromScriptWithFileName(code, fileName)
+            Unit
+        }
+    }
+
     suspend fun loadAllSources(): Result<List<SourceInterface>> = withContext(Dispatchers.IO) {
         runCatching {
             val sources = loadInstalledSources()

--- a/scraper/src/main/java/my/noveldokusha/scraper/LuaSourceProvider.kt
+++ b/scraper/src/main/java/my/noveldokusha/scraper/LuaSourceProvider.kt
@@ -18,6 +18,9 @@ interface LuaSourceProvider {
     /** Ждёт завершения загрузки реальных Lua скриптов. Возвращает мгновенно если уже загружены. */
     suspend fun awaitLoaded()
 
+    /** Reload installed Lua sources from disk and repository settings. */
+    suspend fun reload()
+
     /** Очистить кэш скомпилированных скриптов */
     fun clearCache()
 }


### PR DESCRIPTION
## 🧩 Local Lua Extension Tools

- 📥 Import local `.lua` source extensions directly in NoveLA
- ✏️ Edit installed Lua extension code with a lightweight built-in editor
- 💾 Save Lua changes locally and reload extensions for quick testing
- ♻️ Restore repository extensions to their original Lua source
- 🗑️ Delete individual local Lua extensions
- 🧹 Clear all locally imported Lua extensions

<table>
  <tr>
    <td align="center"><b>Local Import Lua</b></td>
    <td align="center"><b>Lua Editor</b></td>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/983f41db-e177-4102-97fb-a9217e235be7" width="300">
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/31a1f4c7-bbcb-4ba8-877a-90f81452b257" width="300">
    </td>
  </tr>
</table>