### PR TITLE
feat: TTS spoken-word highlighting (Spotify-style word highlight)

### DIFF
--- a/core/src/main/java/my/noveldokusha/core/appPreferences/AppPreferences.kt
+++ b/core/src/main/java/my/noveldokusha/core/appPreferences/AppPreferences.kt
@@ -188,6 +188,14 @@ class AppPreferences @Inject constructor(
         override var value by SharedPreference_Boolean(name, preferences, false)
     }
 
+    val TTS_HIGHLIGHT_ENABLED = object : Preference<Boolean>("TTS_HIGHLIGHT_ENABLED") {
+        override var value by SharedPreference_Boolean(name, preferences, false)
+    }
+
+    val TTS_HIGHLIGHT_COLOR = object : Preference<String>("TTS_HIGHLIGHT_COLOR") {
+        override var value by SharedPreference_String(name, preferences, "FFFF6D00")
+    }
+
     val CHAPTERS_SORT_ASCENDING = object : Preference<TernaryState>("CHAPTERS_SORT_ASCENDING") {
         override var value by SharedPreference_Enum(
             name,

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -153,7 +154,6 @@ class ReaderActivity : BaseActivity() {
                 currentTtsHighlightEnabled = { appPreferences.TTS_HIGHLIGHT_ENABLED.value },
                 currentTtsHighlightColor = { appPreferences.TTS_HIGHLIGHT_COLOR.value },
                 currentSpokenWordRange = { viewModel.readerSpeaker.state.spokenWordRange.value },
-                currentTtsParagraphText = { viewModel.readerSpeaker.state.currentParagraphText.value },
             )
         }
     }
@@ -336,6 +336,7 @@ class ReaderActivity : BaseActivity() {
         lifecycleScope.launch {
             var lastRange: IntRange? = null
             snapshotFlow { viewModel.readerSpeaker.state.spokenWordRange.value }
+                .debounce(50)
                 .collect {
                     if (appPreferences.TTS_HIGHLIGHT_ENABLED.value && it != null && it != lastRange) {
                         lastRange = it

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
@@ -150,6 +150,10 @@ class ReaderActivity : BaseActivity() {
                         }
                     }
                 },
+                currentTtsHighlightEnabled = { appPreferences.TTS_HIGHLIGHT_ENABLED.value },
+                currentTtsHighlightColor = { appPreferences.TTS_HIGHLIGHT_COLOR.value },
+                currentTtsWordIndex = { viewModel.readerSpeaker.currentWordIndex.value },
+                currentTtsParagraphText = { viewModel.readerSpeaker.state.currentParagraphText.value },
             )
         }
     }
@@ -321,6 +325,26 @@ class ReaderActivity : BaseActivity() {
             .asLiveData()
             .observe(this) { viewAdapter.listView.notifyDataSetChanged() }
 
+        // Notify TTS highlight changed for list view
+        snapshotFlow {
+            appPreferences.TTS_HIGHLIGHT_ENABLED.value to appPreferences.TTS_HIGHLIGHT_COLOR.value
+        }.drop(1)
+            .asLiveData()
+            .observe(this) { viewAdapter.listView.notifyDataSetChanged() }
+
+        // Periodic refresh for TTS word highlighting while playing
+        lifecycleScope.launch {
+            var lastWordIndex = -1
+            snapshotFlow { viewModel.readerSpeaker.currentWordIndex.value }
+                .collect {
+                    if (appPreferences.TTS_HIGHLIGHT_ENABLED.value && it >= 0 && it != lastWordIndex) {
+                        lastWordIndex = it
+                        viewAdapter.listView.notifyDataSetChanged()
+                    }
+                    if (it < 0) lastWordIndex = -1
+                }
+        }
+
         // Set current screen to be kept bright always or not
         snapshotFlow { viewModel.state.settings.keepScreenOn.value }
             .asLiveData()
@@ -347,6 +371,8 @@ class ReaderActivity : BaseActivity() {
                     onAppThemeChanged = { appPreferences.APP_THEME.value = it.name; recreate() },
                     onFullScreen = { appPreferences.READER_FULL_SCREEN.value = it; recreate() },
                     onSingleTapToOpenSettingsChange = { appPreferences.READER_SINGLE_TAP_TO_OPEN_SETTINGS.value = it },
+                    onTtsHighlightEnabledChange = { appPreferences.TTS_HIGHLIGHT_ENABLED.value = it },
+                    onTtsHighlightColorChange = { appPreferences.TTS_HIGHLIGHT_COLOR.value = it },
                     onPressBack = {
                         viewModel.onCloseManually()
                         finish()

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
@@ -152,7 +152,7 @@ class ReaderActivity : BaseActivity() {
                 },
                 currentTtsHighlightEnabled = { appPreferences.TTS_HIGHLIGHT_ENABLED.value },
                 currentTtsHighlightColor = { appPreferences.TTS_HIGHLIGHT_COLOR.value },
-                currentTtsWordIndex = { viewModel.readerSpeaker.currentWordIndex.value },
+                currentSpokenWordRange = { viewModel.readerSpeaker.state.spokenWordRange.value },
                 currentTtsParagraphText = { viewModel.readerSpeaker.state.currentParagraphText.value },
             )
         }
@@ -334,14 +334,14 @@ class ReaderActivity : BaseActivity() {
 
         // Periodic refresh for TTS word highlighting while playing
         lifecycleScope.launch {
-            var lastWordIndex = -1
-            snapshotFlow { viewModel.readerSpeaker.currentWordIndex.value }
+            var lastRange: IntRange? = null
+            snapshotFlow { viewModel.readerSpeaker.state.spokenWordRange.value }
                 .collect {
-                    if (appPreferences.TTS_HIGHLIGHT_ENABLED.value && it >= 0 && it != lastWordIndex) {
-                        lastWordIndex = it
+                    if (appPreferences.TTS_HIGHLIGHT_ENABLED.value && it != null && it != lastRange) {
+                        lastRange = it
                         viewAdapter.listView.notifyDataSetChanged()
                     }
-                    if (it < 0) lastWordIndex = -1
+                    if (it == null) lastRange = null
                 }
         }
 

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderViewModel.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderViewModel.kt
@@ -74,6 +74,10 @@ internal class ReaderViewModel @Inject constructor(
                 showOutsideApp = appPreferences.FLOATING_TTS_SHOW_OUTSIDE_APP.state(viewModelScope),
                 opacity = appPreferences.FLOATING_TTS_OPACITY.state(viewModelScope),
             ),
+            ttsHighlight = ReaderScreenState.Settings.TtsHighlightSettingsData(
+                isEnabled = appPreferences.TTS_HIGHLIGHT_ENABLED.state(viewModelScope),
+                highlightColor = appPreferences.TTS_HIGHLIGHT_COLOR.state(viewModelScope),
+            ),
             style = ReaderScreenState.Settings.StyleSettingsData(
                 currentDarkMode = mutableStateOf(DarkMode.SYSTEM).also { state ->
                     viewModelScope.launch {

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/domain/ReaderItemAdapter.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/domain/ReaderItemAdapter.kt
@@ -4,9 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
 import android.text.SpannableString
 import android.text.Spanned
-import android.text.style.BackgroundColorSpan
+import android.text.style.ReplacementSpan
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -56,7 +59,6 @@ internal class ReaderItemAdapter(
     private val currentTtsHighlightEnabled: () -> Boolean = { false },
     private val currentTtsHighlightColor: () -> String = { "FFFF6D00" },
     private val currentSpokenWordRange: () -> IntRange? = { null },
-    private val currentTtsParagraphText: () -> String = { "" },
 ) : ArrayAdapter<ReaderItem>(ctx, 0, list) {
     private val appFileResolver = AppFileResolver(ctx)
     override fun getCount() = super.getCount() + 2
@@ -151,7 +153,7 @@ internal class ReaderItemAdapter(
 
         val parallelEnabled = currentParallelEnabled() && item.textTranslated != null
 
-        val isTtsActiveItem = item is ReaderItem.Position &&
+        val isTtsActiveItem =
                 currentSpeakerActiveItem().itemPos.chapterIndex == item.chapterIndex &&
                 currentSpeakerActiveItem().itemPos.chapterItemPosition == item.chapterItemPosition &&
                 currentSpeakerActiveItem().playState == Utterance.PlayState.PLAYING
@@ -163,7 +165,7 @@ internal class ReaderItemAdapter(
             val secondaryText = if (orderTranslationFirst) item.text else item.textTranslated ?: item.text
 
             val displayPrimary = if (isTtsActiveItem && currentTtsHighlightEnabled()) {
-                applyWordHighlight(primaryText, 0, currentTtsHighlightColor())
+                applyWordHighlight(primaryText, currentTtsHighlightColor())
             } else {
                 primaryText
             }
@@ -182,7 +184,7 @@ internal class ReaderItemAdapter(
             bind.bodyOriginal.visibility = View.VISIBLE
         } else {
             val displayText = if (isTtsActiveItem && currentTtsHighlightEnabled()) {
-                applyWordHighlight(item.textToDisplay, 0, currentTtsHighlightColor())
+                applyWordHighlight(item.textToDisplay, currentTtsHighlightColor())
             } else {
                 item.textToDisplay
             }
@@ -389,7 +391,7 @@ internal class ReaderItemAdapter(
         }
     }
 
-    private fun applyWordHighlight(text: String, wordIndex: Int, highlightColorHex: String): CharSequence {
+    private fun applyWordHighlight(text: String, highlightColorHex: String): CharSequence {
         if (!currentTtsHighlightEnabled() || text.isBlank()) return text
         val range = currentSpokenWordRange()
         if (range == null || range.first >= text.length) return text
@@ -403,7 +405,7 @@ internal class ReaderItemAdapter(
         val end = (range.last + 1).coerceIn(0, text.length)
         if (start < end) {
             spannable.setSpan(
-                BackgroundColorSpan(color),
+                RoundedBackgroundSpan(color),
                 start, end,
                 Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
             )
@@ -454,5 +456,27 @@ internal class ReaderItemAdapter(
 
     companion object {
         private const val MENU_ID_SEARCH_WEB = 9999
+    }
+}
+
+private class RoundedBackgroundSpan(private val color: Int) : ReplacementSpan() {
+    override fun getSize(paint: Paint, text: CharSequence, start: Int, end: Int, fm: Paint.FontMetricsInt?): Int {
+        return paint.measureText(text, start, end).toInt()
+    }
+
+    override fun draw(canvas: Canvas, text: CharSequence, start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint) {
+        val textWidth = paint.measureText(text, start, end)
+        val fm = paint.fontMetricsInt
+        val pad = 3f
+        val rect = RectF(
+            x, (y + fm.ascent).toFloat() - pad,
+            x + textWidth, (y + fm.descent).toFloat() + pad
+        )
+        val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = (this@RoundedBackgroundSpan.color and 0x00FFFFFF) or (0x80 shl 24)
+            style = Paint.Style.FILL
+        }
+        canvas.drawRoundRect(rect, 6f, 6f, bgPaint)
+        canvas.drawText(text, start, end, x, y.toFloat(), paint)
     }
 }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/domain/ReaderItemAdapter.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/domain/ReaderItemAdapter.kt
@@ -4,6 +4,11 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
+import android.text.SpannableString
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.BackgroundColorSpan
+import android.text.style.ForegroundColorSpan
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -50,6 +55,10 @@ internal class ReaderItemAdapter(
     private val onRetryChapter: (chapterIndex: Int) -> Unit,
     private val onOpenChapterInBrowser: (url: String) -> Unit,
     private val onClick: () -> Unit,
+    private val currentTtsHighlightEnabled: () -> Boolean = { false },
+    private val currentTtsHighlightColor: () -> String = { "FFFF6D00" },
+    private val currentTtsWordIndex: () -> Int = { -1 },
+    private val currentTtsParagraphText: () -> String = { "" },
 ) : ArrayAdapter<ReaderItem>(ctx, 0, list) {
     private val appFileResolver = AppFileResolver(ctx)
     override fun getCount() = super.getCount() + 2
@@ -144,13 +153,24 @@ internal class ReaderItemAdapter(
 
         val parallelEnabled = currentParallelEnabled() && item.textTranslated != null
 
+        val isTtsActiveItem = item is ReaderItem.Position &&
+                currentSpeakerActiveItem().itemPos.chapterIndex == item.chapterIndex &&
+                currentSpeakerActiveItem().itemPos.chapterItemPosition == item.chapterItemPosition &&
+                currentSpeakerActiveItem().playState == Utterance.PlayState.PLAYING
+
         if (parallelEnabled) {
             val orderTranslationFirst = currentParallelOrder() == "TRANSLATION_FIRST"
 
             val primaryText = if (orderTranslationFirst) item.textTranslated ?: item.text else item.text
             val secondaryText = if (orderTranslationFirst) item.text else item.textTranslated ?: item.text
 
-            bind.bodyTranslated.text = primaryText
+            val displayPrimary = if (isTtsActiveItem && currentTtsHighlightEnabled()) {
+                applyWordHighlight(primaryText, currentTtsWordIndex(), currentTtsHighlightColor())
+            } else {
+                primaryText
+            }
+
+            bind.bodyTranslated.text = displayPrimary
             bind.bodyTranslated.textSize = currentFontSize()
             bind.bodyTranslated.typeface = currentTypeface()
             bind.bodyTranslated.updateTextSelectability()
@@ -163,7 +183,13 @@ internal class ReaderItemAdapter(
             bind.bodyOriginal.setLineSpacing(0f, currentLineHeight())
             bind.bodyOriginal.visibility = View.VISIBLE
         } else {
-            bind.bodyTranslated.text = item.textToDisplay
+            val displayText = if (isTtsActiveItem && currentTtsHighlightEnabled()) {
+                applyWordHighlight(item.textToDisplay, currentTtsWordIndex(), currentTtsHighlightColor())
+            } else {
+                item.textToDisplay
+            }
+
+            bind.bodyTranslated.text = displayText
             bind.bodyTranslated.textSize = currentFontSize()
             bind.bodyTranslated.typeface = currentTypeface()
             bind.bodyTranslated.updateTextSelectability()
@@ -363,6 +389,44 @@ internal class ReaderItemAdapter(
             setOnClickListener { onClick() }
             setOnTouchListener(null)
         }
+    }
+
+    private fun applyWordHighlight(text: String, wordIndex: Int, highlightColorHex: String): CharSequence {
+        if (!currentTtsHighlightEnabled() || wordIndex < 0 || text.isBlank()) return text
+        val color = try {
+            android.graphics.Color.parseColor("#$highlightColorHex")
+        } catch (_: Exception) {
+            android.graphics.Color.parseColor("#FFFF6D00")
+        }
+        val spannable = SpannableString(text)
+        val words = text.split(Regex("\\s+")).filter { it.isNotEmpty() }
+        if (words.isEmpty() || wordIndex >= words.size) return text
+        var pos = 0
+        for ((i, word) in words.withIndex()) {
+            val start = text.indexOf(word, pos)
+            if (start == -1) { pos += word.length; continue }
+            val end = start + word.length
+            if (i == wordIndex) {
+                spannable.setSpan(
+                    BackgroundColorSpan(color),
+                    start, end,
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+                spannable.setSpan(
+                    ForegroundColorSpan(android.graphics.Color.WHITE),
+                    start, end,
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+            } else {
+                spannable.setSpan(
+                    ForegroundColorSpan(android.graphics.Color.TRANSPARENT),
+                    start, end,
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+            }
+            pos = end
+        }
+        return spannable
     }
 
     private fun getItemReadingStateBackground(item: ReaderItem): Drawable? {

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/domain/ReaderItemAdapter.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/domain/ReaderItemAdapter.kt
@@ -5,10 +5,8 @@ import android.content.Intent
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.text.SpannableString
-import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.BackgroundColorSpan
-import android.text.style.ForegroundColorSpan
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -57,7 +55,7 @@ internal class ReaderItemAdapter(
     private val onClick: () -> Unit,
     private val currentTtsHighlightEnabled: () -> Boolean = { false },
     private val currentTtsHighlightColor: () -> String = { "FFFF6D00" },
-    private val currentTtsWordIndex: () -> Int = { -1 },
+    private val currentSpokenWordRange: () -> IntRange? = { null },
     private val currentTtsParagraphText: () -> String = { "" },
 ) : ArrayAdapter<ReaderItem>(ctx, 0, list) {
     private val appFileResolver = AppFileResolver(ctx)
@@ -165,7 +163,7 @@ internal class ReaderItemAdapter(
             val secondaryText = if (orderTranslationFirst) item.text else item.textTranslated ?: item.text
 
             val displayPrimary = if (isTtsActiveItem && currentTtsHighlightEnabled()) {
-                applyWordHighlight(primaryText, currentTtsWordIndex(), currentTtsHighlightColor())
+                applyWordHighlight(primaryText, 0, currentTtsHighlightColor())
             } else {
                 primaryText
             }
@@ -184,7 +182,7 @@ internal class ReaderItemAdapter(
             bind.bodyOriginal.visibility = View.VISIBLE
         } else {
             val displayText = if (isTtsActiveItem && currentTtsHighlightEnabled()) {
-                applyWordHighlight(item.textToDisplay, currentTtsWordIndex(), currentTtsHighlightColor())
+                applyWordHighlight(item.textToDisplay, 0, currentTtsHighlightColor())
             } else {
                 item.textToDisplay
             }
@@ -392,39 +390,23 @@ internal class ReaderItemAdapter(
     }
 
     private fun applyWordHighlight(text: String, wordIndex: Int, highlightColorHex: String): CharSequence {
-        if (!currentTtsHighlightEnabled() || wordIndex < 0 || text.isBlank()) return text
+        if (!currentTtsHighlightEnabled() || text.isBlank()) return text
+        val range = currentSpokenWordRange()
+        if (range == null || range.first >= text.length) return text
         val color = try {
             android.graphics.Color.parseColor("#$highlightColorHex")
         } catch (_: Exception) {
             android.graphics.Color.parseColor("#FFFF6D00")
         }
         val spannable = SpannableString(text)
-        val words = text.split(Regex("\\s+")).filter { it.isNotEmpty() }
-        if (words.isEmpty() || wordIndex >= words.size) return text
-        var pos = 0
-        for ((i, word) in words.withIndex()) {
-            val start = text.indexOf(word, pos)
-            if (start == -1) { pos += word.length; continue }
-            val end = start + word.length
-            if (i == wordIndex) {
-                spannable.setSpan(
-                    BackgroundColorSpan(color),
-                    start, end,
-                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
-                )
-                spannable.setSpan(
-                    ForegroundColorSpan(android.graphics.Color.WHITE),
-                    start, end,
-                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
-                )
-            } else {
-                spannable.setSpan(
-                    ForegroundColorSpan(android.graphics.Color.TRANSPARENT),
-                    start, end,
-                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
-                )
-            }
-            pos = end
+        val start = range.first.coerceIn(0, text.length)
+        val end = (range.last + 1).coerceIn(0, text.length)
+        if (start < end) {
+            spannable.setSpan(
+                BackgroundColorSpan(color),
+                start, end,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
         }
         return spannable
     }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderTextToSpeech.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderTextToSpeech.kt
@@ -67,7 +67,6 @@ internal data class TextToSpeechSettingData(
     val parallelEnabled: State<Boolean>,
     val originalVoiceId: State<String>,
     val setOriginalVoiceId: (String) -> Unit,
-    val currentWordIndex: State<Int>,
     val spokenWordRange: State<IntRange?>,
 )
 
@@ -273,7 +272,6 @@ internal class ReaderTextToSpeech(
             _originalVoiceId.value = voiceId
             onOriginalVoiceChanged()
         },
-        currentWordIndex = mutableStateOf(-1),
         spokenWordRange = manager.spokenWordRange,
     )
 
@@ -961,12 +959,17 @@ internal class ReaderTextToSpeech(
                 val cleanText = cleanTextForTts(displayText)
                 if (cleanText.isBlank()) return
 
+                val leadingOffset = displayText.lines().firstOrNull()?.let { line ->
+                    LEADING_DECORATIVE.find(line)?.value?.length
+                } ?: 0
+
                 manager.speak(
                     text = cleanText,
                     textSynthesis = TextSynthesis(
                         itemPos = item,
                         playState = Utterance.PlayState.PLAYING
-                    )
+                    ),
+                    leadingOffset = leadingOffset
                 )
             }
             else -> Unit

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderTextToSpeech.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderTextToSpeech.kt
@@ -67,6 +67,7 @@ internal data class TextToSpeechSettingData(
     val parallelEnabled: State<Boolean>,
     val originalVoiceId: State<String>,
     val setOriginalVoiceId: (String) -> Unit,
+    val currentWordIndex: State<Int>,
 )
 
 internal data class TextSynthesis(
@@ -215,6 +216,9 @@ internal class ReaderTextToSpeech(
         }
     }
 
+    private val _currentWordIndex = mutableStateOf(-1)
+    val currentWordIndex: State<Int> = _currentWordIndex
+
     val alternateParagraphText = derivedStateOf {
         val itemPos = manager.currentActiveItemState.value.itemPos
         val itemIndex = indexOfReaderItem(
@@ -271,6 +275,7 @@ internal class ReaderTextToSpeech(
             _originalVoiceId.value = voiceId
             onOriginalVoiceChanged()
         },
+        currentWordIndex = _currentWordIndex,
     )
 
     val isActive = derivedStateOf { state.isThereActiveItem.value || state.isPlaying.value }
@@ -344,6 +349,66 @@ internal class ReaderTextToSpeech(
                     }
                     else -> Unit
                 }
+            }
+        }
+
+        // Word index tracking for TTS highlight
+        coroutineScope.launch {
+            var wordsCache = emptyArray<String>()
+            var totalEstimatedMs = 1L
+            var currentUtteranceId = ""
+
+            manager.currentTextSpeakFlow.collect { utterance ->
+                when (utterance.playState) {
+                    Utterance.PlayState.PLAYING -> {
+                        val text = manager.currentSpeakingText.value
+                        if (text.isNotBlank()) {
+                            wordsCache = WHITESPACE.split(text).filter { it.isNotEmpty() }.toTypedArray()
+                            val currentSpeed = manager.voiceSpeed.floatValue
+                            val cps = baseCharactersPerSecond.value * currentSpeed
+                            totalEstimatedMs = if (cps > 0f) {
+                                ((text.length / cps) * 1000L).coerceAtLeast(1)
+                            } else {
+                                (wordsCache.size * 500L).coerceAtLeast(1)
+                            }
+                            currentUtteranceId = utterance.utteranceId
+                            _currentWordIndex.value = 0
+                        }
+                    }
+                    Utterance.PlayState.FINISHED -> {
+                        if (utterance.utteranceId == currentUtteranceId) {
+                            _currentWordIndex.value = -1
+                            currentUtteranceId = ""
+                        }
+                    }
+                    else -> Unit
+                }
+            }
+        }
+
+        // Periodic word index update based on elapsed time
+        coroutineScope.launch {
+            while (true) {
+                delay(50)
+                val startTime = manager.speechStartTimeMs.value
+                val text = manager.currentSpeakingText.value
+                if (startTime <= 0L || text.isBlank() || _currentWordIndex.value < 0) continue
+
+                val elapsedMs = System.currentTimeMillis() - startTime
+                val words = WHITESPACE.split(text).filter { it.isNotEmpty() }
+                if (words.isEmpty()) continue
+
+                val currentSpeed = manager.voiceSpeed.floatValue
+                val cps = baseCharactersPerSecond.value * currentSpeed
+                val totalMs = if (cps > 0f) {
+                    ((text.length / cps) * 1000L).coerceAtLeast(1)
+                } else {
+                    (words.size * 500L).coerceAtLeast(1)
+                }
+
+                val progress = (elapsedMs.toFloat() / totalMs).coerceIn(0f, 1f)
+                val wordIndex = (progress * words.size).toInt().coerceIn(0, words.size - 1)
+                _currentWordIndex.value = wordIndex
             }
         }
     }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderTextToSpeech.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderTextToSpeech.kt
@@ -367,9 +367,9 @@ internal class ReaderTextToSpeech(
                             val currentSpeed = manager.voiceSpeed.floatValue
                             val cps = baseCharactersPerSecond.value * currentSpeed
                             totalEstimatedMs = if (cps > 0f) {
-                                ((text.length / cps) * 1000L).coerceAtLeast(1)
+                                ((text.length.toFloat() / cps) * 1000L).toLong().coerceAtLeast(1)
                             } else {
-                                (wordsCache.size * 500L).coerceAtLeast(1)
+                                (wordsCache.size.toLong() * 500L).coerceAtLeast(1)
                             }
                             currentUtteranceId = utterance.utteranceId
                             _currentWordIndex.value = 0
@@ -401,12 +401,12 @@ internal class ReaderTextToSpeech(
                 val currentSpeed = manager.voiceSpeed.floatValue
                 val cps = baseCharactersPerSecond.value * currentSpeed
                 val totalMs = if (cps > 0f) {
-                    ((text.length / cps) * 1000L).coerceAtLeast(1)
+                    ((text.length.toFloat() / cps) * 1000L).toLong().coerceAtLeast(1)
                 } else {
-                    (words.size * 500L).coerceAtLeast(1)
+                    (words.size.toLong() * 500L).coerceAtLeast(1)
                 }
 
-                val progress = (elapsedMs.toFloat() / totalMs).coerceIn(0f, 1f)
+                val progress = (elapsedMs.toFloat() / totalMs.toFloat()).coerceIn(0f, 1f)
                 val wordIndex = (progress * words.size).toInt().coerceIn(0, words.size - 1)
                 _currentWordIndex.value = wordIndex
             }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderTextToSpeech.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderTextToSpeech.kt
@@ -68,6 +68,7 @@ internal data class TextToSpeechSettingData(
     val originalVoiceId: State<String>,
     val setOriginalVoiceId: (String) -> Unit,
     val currentWordIndex: State<Int>,
+    val spokenWordRange: State<IntRange?>,
 )
 
 internal data class TextSynthesis(
@@ -216,9 +217,6 @@ internal class ReaderTextToSpeech(
         }
     }
 
-    private val _currentWordIndex = mutableStateOf(-1)
-    val currentWordIndex: State<Int> = _currentWordIndex
-
     val alternateParagraphText = derivedStateOf {
         val itemPos = manager.currentActiveItemState.value.itemPos
         val itemIndex = indexOfReaderItem(
@@ -275,7 +273,8 @@ internal class ReaderTextToSpeech(
             _originalVoiceId.value = voiceId
             onOriginalVoiceChanged()
         },
-        currentWordIndex = _currentWordIndex,
+        currentWordIndex = mutableStateOf(-1),
+        spokenWordRange = manager.spokenWordRange,
     )
 
     val isActive = derivedStateOf { state.isThereActiveItem.value || state.isPlaying.value }
@@ -349,66 +348,6 @@ internal class ReaderTextToSpeech(
                     }
                     else -> Unit
                 }
-            }
-        }
-
-        // Word index tracking for TTS highlight
-        coroutineScope.launch {
-            var wordsCache = emptyArray<String>()
-            var totalEstimatedMs = 1L
-            var currentUtteranceId = ""
-
-            manager.currentTextSpeakFlow.collect { utterance ->
-                when (utterance.playState) {
-                    Utterance.PlayState.PLAYING -> {
-                        val text = manager.currentSpeakingText.value
-                        if (text.isNotBlank()) {
-                            wordsCache = WHITESPACE.split(text).filter { it.isNotEmpty() }.toTypedArray()
-                            val currentSpeed = manager.voiceSpeed.floatValue
-                            val cps = baseCharactersPerSecond.value * currentSpeed
-                            totalEstimatedMs = if (cps > 0f) {
-                                ((text.length.toFloat() / cps) * 1000L).toLong().coerceAtLeast(1)
-                            } else {
-                                (wordsCache.size.toLong() * 500L).coerceAtLeast(1)
-                            }
-                            currentUtteranceId = utterance.utteranceId
-                            _currentWordIndex.value = 0
-                        }
-                    }
-                    Utterance.PlayState.FINISHED -> {
-                        if (utterance.utteranceId == currentUtteranceId) {
-                            _currentWordIndex.value = -1
-                            currentUtteranceId = ""
-                        }
-                    }
-                    else -> Unit
-                }
-            }
-        }
-
-        // Periodic word index update based on elapsed time
-        coroutineScope.launch {
-            while (true) {
-                delay(50)
-                val startTime = manager.speechStartTimeMs.value
-                val text = manager.currentSpeakingText.value
-                if (startTime <= 0L || text.isBlank() || _currentWordIndex.value < 0) continue
-
-                val elapsedMs = System.currentTimeMillis() - startTime
-                val words = WHITESPACE.split(text).filter { it.isNotEmpty() }
-                if (words.isEmpty()) continue
-
-                val currentSpeed = manager.voiceSpeed.floatValue
-                val cps = baseCharactersPerSecond.value * currentSpeed
-                val totalMs = if (cps > 0f) {
-                    ((text.length.toFloat() / cps) * 1000L).toLong().coerceAtLeast(1)
-                } else {
-                    (words.size.toLong() * 500L).coerceAtLeast(1)
-                }
-
-                val progress = (elapsedMs.toFloat() / totalMs.toFloat()).coerceIn(0f, 1f)
-                val wordIndex = (progress * words.size).toInt().coerceIn(0, words.size - 1)
-                _currentWordIndex.value = wordIndex
             }
         }
     }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/services/FloatingTtsService.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/services/FloatingTtsService.kt
@@ -57,6 +57,8 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
         var opacity = mutableFloatStateOf(0.6f)
         var panelWidth by mutableFloatStateOf(300f)
         var paragraphMode by mutableStateOf("tts")
+        var ttsHighlightEnabled = mutableStateOf(false)
+        var ttsHighlightColor = mutableStateOf("FFFF6D00")
         var activityWindowToken: IBinder? = null
 
         private var isExpanded = mutableStateOf(false)
@@ -387,6 +389,8 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
                             paragraphMode = newMode
                             appPreferences.FLOATING_TTS_PARAGRAPH_MODE.value = newMode
                         },
+                        ttsHighlightEnabled = ttsHighlightEnabled.value,
+                        ttsHighlightColor = ttsHighlightColor.value,
                     )
                 }
             }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/FloatingTtsOverlay.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/FloatingTtsOverlay.kt
@@ -41,6 +41,8 @@ internal fun FloatingTtsOverlayContent(
     onShowTextToggle: (() -> Unit)? = null,
     paragraphMode: String = "tts",
     onParagraphModeChange: ((String) -> Unit)? = null,
+    ttsHighlightEnabled: Boolean = false,
+    ttsHighlightColor: String = "FFFF6D00",
 ) {
     if (isExpanded) {
         TtsMiniPlayer(
@@ -59,6 +61,8 @@ internal fun FloatingTtsOverlayContent(
             onShowTextToggle = onShowTextToggle,
             paragraphMode = paragraphMode,
             onParagraphModeChange = onParagraphModeChange,
+            ttsHighlightEnabled = ttsHighlightEnabled,
+            ttsHighlightColor = ttsHighlightColor,
         )
     } else {
         FloatingBubble(

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreen.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreen.kt
@@ -518,7 +518,6 @@ private fun ViewsPreview(
         parallelEnabled = remember { mutableStateOf(false) },
         originalVoiceId = remember { mutableStateOf("") },
         setOriginalVoiceId = {},
-        currentWordIndex = remember { mutableStateOf(-1) },
         spokenWordRange = remember { mutableStateOf(null) },
     )
 

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreen.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreen.kt
@@ -519,6 +519,7 @@ private fun ViewsPreview(
         originalVoiceId = remember { mutableStateOf("") },
         setOriginalVoiceId = {},
         currentWordIndex = remember { mutableStateOf(-1) },
+        spokenWordRange = remember { mutableStateOf(null) },
     )
 
     val style = ReaderScreenState.Settings.StyleSettingsData(

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreen.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreen.kt
@@ -105,6 +105,8 @@ internal fun ReaderScreen(
     onParagraphSpacingChanged: (Float) -> Unit,
     onPressBack: () -> Unit,
     onOpenChapterInWeb: () -> Unit,
+    onTtsHighlightEnabledChange: (Boolean) -> Unit,
+    onTtsHighlightColorChange: (String) -> Unit,
     readerContent: @Composable (paddingValues: PaddingValues) -> Unit,
 ) {
     val showReaderInfo by state.showReaderInfo
@@ -223,6 +225,8 @@ internal fun ReaderScreen(
                         onKeepScreenOn = onKeepScreenOn,
                         onFullScreen = onFullScreen,
                         onSingleTapToOpenSettingsChange = onSingleTapToOpenSettingsChange,
+                        onTtsHighlightEnabledChange = onTtsHighlightEnabledChange,
+                        onTtsHighlightColorChange = onTtsHighlightColorChange,
                         modifier = Modifier.padding(bottom = 8.dp)
                     )
                     BottomAppBar(
@@ -324,6 +328,10 @@ internal fun ReaderScreen(
                         state.settings.floatingTts.showOutsideApp.value
                     my.noveldokusha.features.reader.services.FloatingTtsService.opacity.value =
                         state.settings.floatingTts.opacity.value
+                    my.noveldokusha.features.reader.services.FloatingTtsService.ttsHighlightEnabled.value =
+                        state.settings.ttsHighlight.isEnabled.value
+                    my.noveldokusha.features.reader.services.FloatingTtsService.ttsHighlightColor.value =
+                        state.settings.ttsHighlight.highlightColor.value
                     my.noveldokusha.features.reader.services.FloatingTtsService.start(context)
                 } else {
                     showOverlayPermissionDialog = true
@@ -337,11 +345,17 @@ internal fun ReaderScreen(
         LaunchedEffect(
             state.settings.floatingTts.showOutsideApp.value,
             state.settings.floatingTts.opacity.value,
+            state.settings.ttsHighlight.isEnabled.value,
+            state.settings.ttsHighlight.highlightColor.value,
         ) {
             my.noveldokusha.features.reader.services.FloatingTtsService.showOutsideApp.value =
                 state.settings.floatingTts.showOutsideApp.value
             my.noveldokusha.features.reader.services.FloatingTtsService.opacity.value =
                 state.settings.floatingTts.opacity.value
+            my.noveldokusha.features.reader.services.FloatingTtsService.ttsHighlightEnabled.value =
+                state.settings.ttsHighlight.isEnabled.value
+            my.noveldokusha.features.reader.services.FloatingTtsService.ttsHighlightColor.value =
+                state.settings.ttsHighlight.highlightColor.value
         }
 
         LaunchedEffect(
@@ -504,6 +518,7 @@ private fun ViewsPreview(
         parallelEnabled = remember { mutableStateOf(false) },
         originalVoiceId = remember { mutableStateOf("") },
         setOriginalVoiceId = {},
+        currentWordIndex = remember { mutableStateOf(-1) },
     )
 
     val style = ReaderScreenState.Settings.StyleSettingsData(
@@ -541,6 +556,10 @@ private fun ViewsPreview(
                             showOutsideApp = remember { mutableStateOf(true) },
                             opacity = remember { mutableFloatStateOf(0.6f) },
                         ),
+                        ttsHighlight = ReaderScreenState.Settings.TtsHighlightSettingsData(
+                            isEnabled = remember { mutableStateOf(false) },
+                            highlightColor = remember { mutableStateOf("FFFF6D00") },
+                        ),
                     ),
                     showInvalidChapterDialog = remember { mutableStateOf(false) }
                 ),
@@ -557,6 +576,8 @@ private fun ViewsPreview(
                 onKeepScreenOn = {},
                 onFullScreen = {},
                 onSingleTapToOpenSettingsChange = {},
+                onTtsHighlightEnabledChange = {},
+                onTtsHighlightColorChange = {},
             )
         }
     }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreenBottomBarDialogs.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreenBottomBarDialogs.kt
@@ -29,6 +29,8 @@ internal fun ReaderScreenBottomBarDialogs(
     onKeepScreenOn: (Boolean) -> Unit,
     onFullScreen: (Boolean) -> Unit,
     onSingleTapToOpenSettingsChange: (Boolean) -> Unit,
+    onTtsHighlightEnabledChange: (Boolean) -> Unit,
+    onTtsHighlightColorChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -66,6 +68,10 @@ internal fun ReaderScreenBottomBarDialogs(
                         onFullScreen = onFullScreen,
                         singleTapToOpenSettings = settings.isSingleTapToOpenSettings.value,
                         onSingleTapToOpenSettingsChange = onSingleTapToOpenSettingsChange,
+                        ttsHighlightEnabled = settings.ttsHighlight.isEnabled.value,
+                        onTtsHighlightEnabledChange = onTtsHighlightEnabledChange,
+                        ttsHighlightColor = settings.ttsHighlight.highlightColor.value,
+                        onTtsHighlightColorChange = onTtsHighlightColorChange,
                     )
                     ReaderScreenState.Settings.Type.None -> Unit
                 }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreenState.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreenState.kt
@@ -36,6 +36,7 @@ internal data class ReaderScreenState(
         val style: StyleSettingsData,
         val selectedSetting: MutableState<Type>,
         val floatingTts: FloatingTtsSettingsData,
+        val ttsHighlight: TtsHighlightSettingsData,
     ) {
         @Stable
         data class StyleSettingsData(
@@ -52,6 +53,12 @@ internal data class ReaderScreenState(
             val isEnabled: MutableState<Boolean>,
             val showOutsideApp: MutableState<Boolean>,
             val opacity: MutableState<Float>,
+        )
+
+        @Stable
+        data class TtsHighlightSettingsData(
+            val isEnabled: MutableState<Boolean>,
+            val highlightColor: MutableState<String>,
         )
 
         @Immutable

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
@@ -45,12 +45,18 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
@@ -522,12 +528,23 @@ private fun FloatingTtsMiniPlayer(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     if (isBothMode) {
+                        val spokenRange = state.spokenWordRange.value
                         Column(modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)) {
-                            Text(
-                                text = ttsParagraph,
-                                style = MaterialTheme.typography.bodySmall.copy(fontSize = paragraphFontSize),
-                                color = MaterialTheme.colorScheme.onSurface,
-                            )
+                            if (ttsHighlightEnabled && spokenRange != null) {
+                                HighlightedText(
+                                    text = ttsParagraph,
+                                    range = spokenRange,
+                                    highlightColorHex = ttsHighlightColor,
+                                    style = MaterialTheme.typography.bodySmall.copy(fontSize = paragraphFontSize),
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            } else {
+                                Text(
+                                    text = ttsParagraph,
+                                    style = MaterialTheme.typography.bodySmall.copy(fontSize = paragraphFontSize),
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                            }
                             Spacer(modifier = Modifier.height(4.dp))
                             Text(
                                 text = inverseParagraph,
@@ -537,17 +554,25 @@ private fun FloatingTtsMiniPlayer(
                         }
                     } else {
                         val spokenRange = state.spokenWordRange.value
-                        val annotatedText: AnnotatedString = if (ttsHighlightEnabled && spokenRange != null) {
-                            buildHighlightedText(displayText, spokenRange, ttsHighlightColor)
+                        val isInverse = paragraphMode == "inverse" && hasInverse
+                        if (ttsHighlightEnabled && spokenRange != null && !isInverse) {
+                            HighlightedText(
+                                text = displayText,
+                                range = spokenRange,
+                                highlightColorHex = ttsHighlightColor,
+                                style = MaterialTheme.typography.bodySmall.copy(fontSize = paragraphFontSize),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 10.dp, vertical = 6.dp),
+                            )
                         } else {
-                            AnnotatedString(displayText)
+                            Text(
+                                text = displayText,
+                                style = MaterialTheme.typography.bodySmall.copy(fontSize = paragraphFontSize),
+                                color = MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)
+                            )
                         }
-                        Text(
-                            text = annotatedText,
-                            style = MaterialTheme.typography.bodySmall.copy(fontSize = paragraphFontSize),
-                            color = MaterialTheme.colorScheme.onSurface,
-                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)
-                        )
                     }
                 }
             }
@@ -579,24 +604,59 @@ internal fun formatDurationCompact(seconds: Int): String {
     }.trimEnd()
 }
 
-private fun buildHighlightedText(text: String, range: IntRange, highlightColorHex: String): AnnotatedString {
-    if (text.isBlank()) return AnnotatedString(text)
-    val color = try {
-        Color(android.graphics.Color.parseColor("#$highlightColorHex"))
-    } catch (_: Exception) {
-        Color(android.graphics.Color.parseColor("#FFFF6D00"))
+@Composable
+private fun HighlightedText(
+    text: String,
+    range: IntRange,
+    highlightColorHex: String,
+    style: TextStyle,
+    modifier: Modifier = Modifier,
+) {
+    var layout by remember { mutableStateOf<TextLayoutResult?>(null) }
+    val bgColor = remember(highlightColorHex) {
+        try {
+            Color(android.graphics.Color.parseColor("#$highlightColorHex"))
+        } catch (_: Exception) {
+            Color(android.graphics.Color.parseColor("#FFFF6D00"))
+        }
     }
-    val start = range.first.coerceIn(0, text.length)
-    val end = (range.last + 1).coerceIn(0, text.length)
-    return buildAnnotatedString {
-        if (start > 0) append(text.substring(0, start))
-        if (start < end) {
-            withStyle(SpanStyle(color = Color.White, background = color, fontWeight = FontWeight.Bold)) {
-                append(text.substring(start, end))
+    val annotated = remember(text, range) {
+        val start = range.first.coerceIn(0, text.length)
+        val end = (range.last + 1).coerceIn(0, text.length)
+        buildAnnotatedString {
+            if (start > 0) append(text.substring(0, start))
+            if (start < end) {
+                withStyle(SpanStyle(color = Color.White, fontWeight = FontWeight.Bold)) {
+                    append(text.substring(start, end))
+                }
+            }
+            if (end < text.length) append(text.substring(end))
+        }
+    }
+    Text(
+        text = annotated,
+        style = style,
+        onTextLayout = { layout = it },
+        modifier = modifier.drawBehind {
+            val l = layout ?: return@drawBehind
+            val start = range.first.coerceIn(0, text.length)
+            val end = (range.last + 1).coerceIn(0, text.length)
+            if (start >= end) return@drawBehind
+
+            val sLine = l.getLineForOffset(start)
+            val eLine = l.getLineForOffset(end - 1).coerceAtLeast(sLine)
+            for (line in sLine..eLine) {
+                val lineStartChar = l.getLineStart(line)
+                val lineEndChar = (l.getLineEnd(line) - 1).coerceAtLeast(lineStartChar)
+                val left = if (line == sLine) l.getBoundingBox(start).left else l.getBoundingBox(lineStartChar).left
+                val right = if (line == eLine) l.getBoundingBox(end - 1).right else l.getBoundingBox(lineEndChar).right
+                drawRoundRect(
+                    color = bgColor.copy(alpha = 0.5f),
+                    topLeft = Offset(left, l.getLineTop(line)),
+                    size = Size(right - left, l.getLineBottom(line) - l.getLineTop(line)),
+                    cornerRadius = CornerRadius(6f)
+                )
             }
         }
-        if (end < text.length) {
-            append(text.substring(end))
-        }
-    }
+    )
 }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
@@ -45,10 +45,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -76,6 +81,8 @@ internal fun TtsMiniPlayer(
     onShowTextToggle: (() -> Unit)? = null,
     paragraphMode: String = "tts",
     onParagraphModeChange: ((String) -> Unit)? = null,
+    ttsHighlightEnabled: Boolean = false,
+    ttsHighlightColor: String = "FFFF6D00",
 ) {
     FloatingTtsMiniPlayer(
         state = state,
@@ -95,6 +102,8 @@ internal fun TtsMiniPlayer(
         onShowTextToggle = onShowTextToggle,
         paragraphMode = paragraphMode,
         onParagraphModeChange = onParagraphModeChange,
+        ttsHighlightEnabled = ttsHighlightEnabled,
+        ttsHighlightColor = ttsHighlightColor,
     )
 }
 
@@ -286,6 +295,8 @@ private fun FloatingTtsMiniPlayer(
     onShowTextToggle: (() -> Unit)?,
     paragraphMode: String = "tts",
     onParagraphModeChange: ((String) -> Unit)? = null,
+    ttsHighlightEnabled: Boolean = false,
+    ttsHighlightColor: String = "FFFF6D00",
 ) {
     val total = state.estimatedTotalSeconds.value
     val remaining = state.estimatedRemainingSeconds.value
@@ -525,8 +536,14 @@ private fun FloatingTtsMiniPlayer(
                             )
                         }
                     } else {
+                        val wordIndex = state.currentWordIndex.value
+                        val annotatedText = if (ttsHighlightEnabled && wordIndex >= 0) {
+                            buildHighlightedText(displayText, wordIndex, ttsHighlightColor)
+                        } else {
+                            displayText
+                        }
                         Text(
-                            text = displayText,
+                            text = annotatedText,
                             style = MaterialTheme.typography.bodySmall.copy(fontSize = paragraphFontSize),
                             color = MaterialTheme.colorScheme.onSurface,
                             modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)
@@ -560,4 +577,43 @@ internal fun formatDurationCompact(seconds: Int): String {
         if (m > 0 || h > 0) append("${m}m ")
         if (s > 0 && h == 0) append("${s}s")
     }.trimEnd()
+}
+
+private val TTS_WHITESPACE = Regex("\\s+")
+
+private fun buildHighlightedText(text: String, wordIndex: Int, highlightColorHex: String): AnnotatedString {
+    if (text.isBlank() || wordIndex < 0) return AnnotatedString(text)
+    val color = try {
+        Color(android.graphics.Color.parseColor("#$highlightColorHex"))
+    } catch (_: Exception) {
+        Color(android.graphics.Color.parseColor("#FFFF6D00"))
+    }
+    val words = TTS_WHITESPACE.split(text)
+    if (words.isEmpty() || wordIndex >= words.size) return AnnotatedString(text)
+    return buildAnnotatedString {
+        var pos = 0
+        for ((i, word) in words.withIndex()) {
+            if (i > 0) {
+                val spaceStart = text.indexOf(word, pos)
+                if (spaceStart > pos) {
+                    append(text.substring(pos, spaceStart))
+                    pos = spaceStart
+                }
+            }
+            val start = text.indexOf(word, pos)
+            if (start == -1) { append(word); pos += word.length; continue }
+            val end = start + word.length
+            if (i == wordIndex) {
+                withStyle(SpanStyle(color = Color.White, background = color, fontWeight = FontWeight.Bold)) {
+                    append(word)
+                }
+            } else {
+                append(word)
+            }
+            pos = end
+        }
+        if (pos < text.length) {
+            append(text.substring(pos))
+        }
+    }
 }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
@@ -537,10 +537,10 @@ private fun FloatingTtsMiniPlayer(
                         }
                     } else {
                         val wordIndex = state.currentWordIndex.value
-                        val annotatedText = if (ttsHighlightEnabled && wordIndex >= 0) {
+                        val annotatedText: AnnotatedString = if (ttsHighlightEnabled && wordIndex >= 0) {
                             buildHighlightedText(displayText, wordIndex, ttsHighlightColor)
                         } else {
-                            displayText
+                            AnnotatedString(displayText)
                         }
                         Text(
                             text = annotatedText,

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
@@ -536,9 +536,9 @@ private fun FloatingTtsMiniPlayer(
                             )
                         }
                     } else {
-                        val wordIndex = state.currentWordIndex.value
-                        val annotatedText: AnnotatedString = if (ttsHighlightEnabled && wordIndex >= 0) {
-                            buildHighlightedText(displayText, wordIndex, ttsHighlightColor)
+                        val spokenRange = state.spokenWordRange.value
+                        val annotatedText: AnnotatedString = if (ttsHighlightEnabled && spokenRange != null) {
+                            buildHighlightedText(displayText, spokenRange, ttsHighlightColor)
                         } else {
                             AnnotatedString(displayText)
                         }
@@ -579,41 +579,24 @@ internal fun formatDurationCompact(seconds: Int): String {
     }.trimEnd()
 }
 
-private val TTS_WHITESPACE = Regex("\\s+")
-
-private fun buildHighlightedText(text: String, wordIndex: Int, highlightColorHex: String): AnnotatedString {
-    if (text.isBlank() || wordIndex < 0) return AnnotatedString(text)
+private fun buildHighlightedText(text: String, range: IntRange, highlightColorHex: String): AnnotatedString {
+    if (text.isBlank()) return AnnotatedString(text)
     val color = try {
         Color(android.graphics.Color.parseColor("#$highlightColorHex"))
     } catch (_: Exception) {
         Color(android.graphics.Color.parseColor("#FFFF6D00"))
     }
-    val words = TTS_WHITESPACE.split(text)
-    if (words.isEmpty() || wordIndex >= words.size) return AnnotatedString(text)
+    val start = range.first.coerceIn(0, text.length)
+    val end = (range.last + 1).coerceIn(0, text.length)
     return buildAnnotatedString {
-        var pos = 0
-        for ((i, word) in words.withIndex()) {
-            if (i > 0) {
-                val spaceStart = text.indexOf(word, pos)
-                if (spaceStart > pos) {
-                    append(text.substring(pos, spaceStart))
-                    pos = spaceStart
-                }
+        if (start > 0) append(text.substring(0, start))
+        if (start < end) {
+            withStyle(SpanStyle(color = Color.White, background = color, fontWeight = FontWeight.Bold)) {
+                append(text.substring(start, end))
             }
-            val start = text.indexOf(word, pos)
-            if (start == -1) { append(word); pos += word.length; continue }
-            val end = start + word.length
-            if (i == wordIndex) {
-                withStyle(SpanStyle(color = Color.White, background = color, fontWeight = FontWeight.Bold)) {
-                    append(word)
-                }
-            } else {
-                append(word)
-            }
-            pos = end
         }
-        if (pos < text.length) {
-            append(text.substring(pos))
+        if (end < text.length) {
+            append(text.substring(end))
         }
     }
 }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/settingDialogs/MoreSettingDialog.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/settingDialogs/MoreSettingDialog.kt
@@ -1,9 +1,19 @@
 package my.noveldokusha.features.reader.ui.settingDialogs
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Fullscreen
 import androidx.compose.material.icons.outlined.LightMode
+import androidx.compose.material.icons.outlined.Paintbrush
 import androidx.compose.material.icons.outlined.TouchApp
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
@@ -14,12 +24,30 @@ import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import my.noveldokusha.coreui.components.SlimListItem
 import my.noveldokusha.coreui.theme.colorAccent
 import my.noveldokusha.reader.R
 
+private val ttsHighlightColors = listOf(
+    "FFFF6D00",  // Deep Orange
+    "FFFF1744",  // Red Accent
+    "FFFF4081",  // Pink Accent
+    "FFE040FB",  // Purple Accent
+    "FF7C4DFF",  // Deep Purple Accent
+    "FF536DFE",  // Indigo Accent
+    "FF448AFF",  // Blue Accent
+    "FF40C4FF",  // Light Blue Accent
+    "FF18FFFF",  // Cyan Accent
+    "FF64FFDA",  // Teal Accent
+    "FF69F0AE",  // Green Accent
+    "FFFFD740",  // Amber Accent
+)
+
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun MoreSettingDialog(
     allowTextSelection: Boolean,
@@ -30,10 +58,66 @@ internal fun MoreSettingDialog(
     onFullScreen: (Boolean) -> Unit,
     singleTapToOpenSettings: Boolean,
     onSingleTapToOpenSettingsChange: (Boolean) -> Unit,
+    ttsHighlightEnabled: Boolean,
+    onTtsHighlightEnabledChange: (Boolean) -> Unit,
+    ttsHighlightColor: String,
+    onTtsHighlightColorChange: (String) -> Unit,
 ) {
     ElevatedCard(
         elevation = CardDefaults.elevatedCardElevation(defaultElevation = 12.dp)
     ) {
+        // TTS Highlight
+        SlimListItem(
+            modifier = Modifier
+                .clickable { onTtsHighlightEnabledChange(!ttsHighlightEnabled) },
+            headlineContent = {
+                Text(text = stringResource(id = R.string.tts_highlight))
+            },
+            leadingContent = {
+                Icon(
+                    Icons.Outlined.Paintbrush,
+                    null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            },
+            trailingContent = {
+                Switch(
+                    checked = ttsHighlightEnabled,
+                    onCheckedChange = onTtsHighlightEnabledChange,
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = colorAccent(),
+                        checkedTrackColor = colorAccent().copy(alpha = 0.4f),
+                    )
+                )
+            }
+        )
+        if (ttsHighlightEnabled) {
+            FlowRow(
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                ttsHighlightColors.forEach { hexColor ->
+                    val isSelected = hexColor == ttsHighlightColor
+                    val color = try {
+                        Color(android.graphics.Color.parseColor("#$hexColor"))
+                    } catch (_: Exception) {
+                        Color(android.graphics.Color.parseColor("#FFFF6D00"))
+                    }
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(CircleShape)
+                            .background(color)
+                            .then(
+                                if (isSelected) Modifier.border(3.dp, MaterialTheme.colorScheme.onSurface, CircleShape)
+                                else Modifier
+                            )
+                            .clickable { onTtsHighlightColorChange(hexColor) }
+                    )
+                }
+            }
+        }
         // Allow text selection
         SlimListItem(
             modifier = Modifier

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/settingDialogs/MoreSettingDialog.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/settingDialogs/MoreSettingDialog.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Fullscreen
 import androidx.compose.material.icons.outlined.LightMode
-import androidx.compose.material.icons.outlined.Paintbrush
+import androidx.compose.material.icons.outlined.FormatPaint
 import androidx.compose.material.icons.outlined.TouchApp
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
@@ -75,7 +75,7 @@ internal fun MoreSettingDialog(
             },
             leadingContent = {
                 Icon(
-                    Icons.Outlined.Paintbrush,
+                    Icons.Outlined.FormatPaint,
                     null,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -157,6 +157,7 @@
     <string name="loading_data">Loading data</string>
     <string name="pin_or_unpin_source">Pin or unpin source</string>
     <string name="allow_text_selection">Text selection</string>
+    <string name="tts_highlight">TTS Highlight</string>
     <string name="last_read">Last read</string>
     <string name="title">Title</string>
     <string name="unread_chapters">Unread chapters</string>

--- a/tooling/text_to_speech/src/main/java/my/noveldokusha/text_to_speech/TextToSpeechManager.kt
+++ b/tooling/text_to_speech/src/main/java/my/noveldokusha/text_to_speech/TextToSpeechManager.kt
@@ -64,6 +64,7 @@ class TextToSpeechManager<T : Utterance<T>>(
 
     val currentSpeakingText = mutableStateOf("")
     val speechStartTimeMs = mutableStateOf(0L)
+    val spokenWordRange = mutableStateOf<IntRange?>(null)
 
     private val auxiliaryServices = mutableListOf<TextToSpeech>()
 
@@ -285,6 +286,7 @@ class TextToSpeechManager<T : Utterance<T>>(
                     ?: return
 
                 speechStartTimeMs.value = System.currentTimeMillis()
+                spokenWordRange.value = null
                 currentActiveItemState.value = res
                 scope.launch { _currentTextSpeakFlow.emit(res) }
             }
@@ -303,6 +305,16 @@ class TextToSpeechManager<T : Utterance<T>>(
             override fun onError(utteranceId: String?) {
                 Timber.w( "onError(deprecated) $utteranceId")
                 onErrorFinished(utteranceId)
+            }
+
+            override fun onRangeStart(utteranceId: String?, start: Int, end: Int, frame: Int) {
+                if (utteranceId != null) {
+                    val parts = utteranceId.split('|')
+                    if (parts.size >= 3) {
+                        val offset = parts[1].toIntOrNull() ?: 0
+                        scope.launch { spokenWordRange.value = (start + offset) until (end + offset) }
+                    }
+                }
             }
 
             private fun onErrorFinished(utteranceId: String?) {

--- a/tooling/text_to_speech/src/main/java/my/noveldokusha/text_to_speech/TextToSpeechManager.kt
+++ b/tooling/text_to_speech/src/main/java/my/noveldokusha/text_to_speech/TextToSpeechManager.kt
@@ -62,6 +62,9 @@ class TextToSpeechManager<T : Utterance<T>>(
         started = SharingStarted.Eagerly
     )
 
+    val currentSpeakingText = mutableStateOf("")
+    val speechStartTimeMs = mutableStateOf(0L)
+
     private val auxiliaryServices = mutableListOf<TextToSpeech>()
 
     // Храним enginePackage сами — service.defaultEngine всегда возвращает системный дефолт,
@@ -191,6 +194,10 @@ class TextToSpeechManager<T : Utterance<T>>(
             }
         }
 
+        if (!enqueueFailed) {
+            currentSpeakingText.value = text
+        }
+
         // ponytail: speak() returning ERROR means none of the slices will play and no
         // callback fires -> the item would stay in the queue forever and freeze reading.
         // Skip it so the session keeps advancing.
@@ -277,6 +284,7 @@ class TextToSpeechManager<T : Utterance<T>>(
                     ?.copyWithState(playState = Utterance.PlayState.PLAYING)
                     ?: return
 
+                speechStartTimeMs.value = System.currentTimeMillis()
                 currentActiveItemState.value = res
                 scope.launch { _currentTextSpeakFlow.emit(res) }
             }

--- a/tooling/text_to_speech/src/main/java/my/noveldokusha/text_to_speech/TextToSpeechManager.kt
+++ b/tooling/text_to_speech/src/main/java/my/noveldokusha/text_to_speech/TextToSpeechManager.kt
@@ -183,8 +183,9 @@ class TextToSpeechManager<T : Utterance<T>>(
 
         Timber.d( "speak id=${textSynthesis.utteranceId} subItems=${subItems.size} queueSize=${_queueList.size}")
         var enqueueFailed = false
+        var currentOffset = 0
         subItems.forEachIndexed { index, textSlice ->
-            val uniqueID = "$index|${textSynthesis.utteranceId}"
+            val uniqueID = "$index|$currentOffset|${textSynthesis.utteranceId}"
             val bundle = Bundle().apply {
                 putString(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, uniqueID)
             }
@@ -193,6 +194,7 @@ class TextToSpeechManager<T : Utterance<T>>(
                 Timber.w( "speak failed id=$uniqueID result=$result")
                 enqueueFailed = true
             }
+            currentOffset += textSlice.length
         }
 
         if (!enqueueFailed) {
@@ -280,7 +282,7 @@ class TextToSpeechManager<T : Utterance<T>>(
                     .toIntOrNull() ?: return
                 if (itemUtteranceIndex != 0) return
 
-                val itemUtteranceId = utteranceId.substringAfter('|')
+                val itemUtteranceId = utteranceId.substringAfterLast('|')
                 val res: T = _queueList[itemUtteranceId]
                     ?.copyWithState(playState = Utterance.PlayState.PLAYING)
                     ?: return
@@ -321,7 +323,7 @@ class TextToSpeechManager<T : Utterance<T>>(
                 if (utteranceId == null) return
                 // Skip the broken item regardless of which sub-slice errored so reading
                 // continues instead of stalling on a permanently stuck queue entry.
-                val itemUtteranceId = utteranceId.substringAfter('|')
+                val itemUtteranceId = utteranceId.substringAfterLast('|')
                 val res: T = _queueList[itemUtteranceId]
                     ?.copyWithState(playState = Utterance.PlayState.FINISHED)
                     ?: return
@@ -339,7 +341,7 @@ class TextToSpeechManager<T : Utterance<T>>(
                         Timber.w( "onFinished: cant parse index from $utteranceId")
                         return
                     }
-                val itemUtteranceId = utteranceId.substringAfter('|')
+                val itemUtteranceId = utteranceId.substringAfterLast('|')
 
                 val itemSize = _queueListItemSize[itemUtteranceId]?.minus(1) ?: run {
                     Timber.w( "onFinished: no itemSize for $itemUtteranceId")

--- a/tooling/text_to_speech/src/main/java/my/noveldokusha/text_to_speech/TextToSpeechManager.kt
+++ b/tooling/text_to_speech/src/main/java/my/noveldokusha/text_to_speech/TextToSpeechManager.kt
@@ -63,7 +63,6 @@ class TextToSpeechManager<T : Utterance<T>>(
     )
 
     val currentSpeakingText = mutableStateOf("")
-    val speechStartTimeMs = mutableStateOf(0L)
     val spokenWordRange = mutableStateOf<IntRange?>(null)
 
     private val auxiliaryServices = mutableListOf<TextToSpeech>()
@@ -172,7 +171,7 @@ class TextToSpeechManager<T : Utterance<T>>(
         _queueListItemSize.clear()
     }
 
-    fun speak(text: String, textSynthesis: T) {
+    fun speak(text: String, textSynthesis: T, leadingOffset: Int = 0) {
         val subItems = delimiterAwareTextSplitter(
             fullText = text,
             maxSliceLength = maxStringLengthPerTextUnit(),
@@ -185,7 +184,7 @@ class TextToSpeechManager<T : Utterance<T>>(
         var enqueueFailed = false
         var currentOffset = 0
         subItems.forEachIndexed { index, textSlice ->
-            val uniqueID = "$index|$currentOffset|${textSynthesis.utteranceId}"
+            val uniqueID = "$index|${currentOffset + leadingOffset}|${textSynthesis.utteranceId}"
             val bundle = Bundle().apply {
                 putString(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, uniqueID)
             }
@@ -287,7 +286,6 @@ class TextToSpeechManager<T : Utterance<T>>(
                     ?.copyWithState(playState = Utterance.PlayState.PLAYING)
                     ?: return
 
-                speechStartTimeMs.value = System.currentTimeMillis()
                 spokenWordRange.value = null
                 currentActiveItemState.value = res
                 scope.launch { _currentTextSpeakFlow.emit(res) }


### PR DESCRIPTION
## ✨ TTS Spoken-Word Highlight (Spotify-style)

Adds real-time word-level highlighting while TTS reads in the reader and floating TTS overlay — the currently spoken word lights up with a colored background, similar to Spotify lyrics sync.

### Demo

<p align="center">
  <video src="https://github.com/user-attachments/assets/fb2ece98-b825-4144-9e57-71675ae641e3" controls width="400"></video>
</p>

### What's New

- **Real-time word highlighting** — Uses Android TTS `onRangeStart` callback for accurate character-level tracking (API 21+)
- **12 color palette** — Deep Orange, Red, Pink, Purple, Indigo, Blue, Cyan, Teal, Green, Amber, and more
- **Toggle on/off** — Enable/disable from reader More Settings, with collapsible color picker
- **Works in both** — Reader paragraph text and floating TTS mini-player overlay
- **Theme-independent** — Highlight colors are separate from app themes

### Technical Details

- **TextToSpeechManager**: `spokenWordRange: MutableState<IntRange?>` with `onRangeStart` callback; 3-part utterance ID (`index|offset|utteranceId`) for accurate offset parsing via `substringAfterLast('|')`
- **ReaderItemAdapter**: `applyWordHighlight()` uses `BackgroundColorSpan` on character ranges — no `ForegroundColorSpan` on non-active text (fixes invisible text bug)
- **TtsMiniPlayer**: `buildHighlightedText()` uses `IntRange` positions for `AnnotatedString` `SpanStyle` coloring
- **AppPreferences**: `TTS_HIGHLIGHT_ENABLED` (Boolean) + `TTS_HIGHLIGHT_COLOR` (String)
- **ReaderScreenState**: New `TtsHighlightSettingsData` data class

### Files Changed

- `core/.../appPreferences/AppPreferences.kt` — New highlight preferences
- `tooling/text_to_speech/.../TextToSpeechManager.kt` — onRangeStart, spokenWordRange, 3-part utterance ID
- `features/reader/.../ReaderTextToSpeech.kt` — Exposes spokenWordRange, removed broken time-based word estimation
- `features/reader/.../ReaderItemAdapter.kt` — Char-range BackgroundColorSpan highlighting
- `features/reader/.../MoreSettingDialog.kt` — Toggle + 12-color palette (FlowRow)
- `features/reader/.../ReaderScreen.kt` — Wired spokenWordRange state
- `features/reader/.../ReaderActivity.kt` — snapshotFlow observer for word range changes
- `features/reader/.../TtsMiniPlayer.kt` — AnnotatedString char-range highlighting
- `features/reader/.../FloatingTtsOverlay.kt` — Pass highlight params
- `features/reader/.../FloatingTtsService.kt` — Static highlight state
- `strings/src/main/res/values/strings.xml` — `tts_highlight` string