### PR TITLE
feat(tts-overlay): double-tap paragraph to hide/show TTS menu controls

### DIFF
--- a/features/reader/src/main/java/my/noveldokusha/features/reader/services/FloatingTtsService.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/services/FloatingTtsService.kt
@@ -12,6 +12,7 @@ import android.graphics.PixelFormat
 import android.os.Build
 import android.os.IBinder
 import android.view.Gravity
+import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
 import androidx.compose.runtime.getValue
@@ -60,6 +61,7 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
         var ttsHighlightEnabled = mutableStateOf(false)
         var ttsHighlightColor = mutableStateOf("FFFF6D00")
         var menuHidden = mutableStateOf(false)
+        var glowActive = mutableStateOf(false)
         var activityWindowToken: IBinder? = null
 
         private var isExpanded = mutableStateOf(false)
@@ -112,6 +114,8 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
     private var windowManager: WindowManager? = null
     private var composeView: ComposeView? = null
     private var currentLayoutParams: WindowManager.LayoutParams? = null
+    private var pinchStartDistance = 0f
+    private var pinchStartWidth = 0f
     private var displayDensity = 1f
     private var displayWidth = 0
     private var displayHeight = 0
@@ -261,6 +265,43 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
         composeView = ComposeView(this).apply {
             setViewTreeLifecycleOwner(this@FloatingTtsService)
             setViewTreeSavedStateRegistryOwner(this@FloatingTtsService)
+            setOnTouchListener { _, event ->
+                if (!isExpanded.value) return@setOnTouchListener false
+                when (event.actionMasked) {
+                    MotionEvent.ACTION_POINTER_DOWN -> {
+                        if (event.pointerCount >= 2) {
+                            val x0 = event.getX(0)
+                            val y0 = event.getY(0)
+                            val x1 = event.getX(1)
+                            val y1 = event.getY(1)
+                            pinchStartDistance = Math.hypot((x0 - x1).toDouble(), (y0 - y1).toDouble()).toFloat()
+                            pinchStartWidth = panelWidth
+                        }
+                        false
+                    }
+                    MotionEvent.ACTION_MOVE -> {
+                        if (pinchStartDistance > 0f && event.pointerCount >= 2) {
+                            val x0 = event.getX(0)
+                            val y0 = event.getY(0)
+                            val x1 = event.getX(1)
+                            val y1 = event.getY(1)
+                            val dist = Math.hypot((x0 - x1).toDouble(), (y0 - y1).toDouble()).toFloat()
+                            val scale = dist / pinchStartDistance
+                            val maxW = (displayWidth / displayDensity) - 16f
+                            val newW = (pinchStartWidth * scale).coerceIn(100f, maxW)
+                            handlePanelWidthChange(newW)
+                        }
+                        false
+                    }
+                    MotionEvent.ACTION_POINTER_UP,
+                    MotionEvent.ACTION_UP,
+                    MotionEvent.ACTION_CANCEL -> {
+                        pinchStartDistance = 0f
+                        false
+                    }
+                    else -> false
+                }
+            }
             setContent {
                 val scope = rememberCoroutineScope()
                 val darkModeState = remember { appPreferences.THEME_DARK_MODE.state(scope) }
@@ -368,15 +409,7 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
                         },
                         panelWidth = panelWidth,
                         onPanelWidthChange = { newWidth ->
-                            panelWidth = newWidth
-                            appPreferences.FLOATING_TTS_PANEL_WIDTH.value = newWidth
-                            val lp = currentLayoutParams
-                            if (lp != null) {
-                                lp.width = (newWidth * displayDensity).toInt()
-                                try {
-                                    windowManager?.updateViewLayout(composeView, lp)
-                                } catch (_: Exception) {}
-                            }
+                            handlePanelWidthChange(newWidth)
                         },
                         opacityValue = opacity.floatValue,
                         onOpacityChange = { newOpacity ->
@@ -398,6 +431,10 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
                         onToggleMenuHidden = {
                             menuHidden.value = !menuHidden.value
                         },
+                        glowActive = glowActive.value,
+                        onToggleGlow = {
+                            glowActive.value = !glowActive.value
+                        },
                     )
                 }
             }
@@ -405,6 +442,18 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
 
         if (composeView?.isAttachedToWindow != true) {
             windowManager?.addView(composeView, layoutParams)
+        }
+    }
+
+    private fun handlePanelWidthChange(newWidth: Float) {
+        panelWidth = newWidth
+        appPreferences.FLOATING_TTS_PANEL_WIDTH.value = newWidth
+        val lp = currentLayoutParams
+        if (lp != null) {
+            lp.width = (newWidth * displayDensity).toInt()
+            try {
+                windowManager?.updateViewLayout(composeView, lp)
+            } catch (_: Exception) {}
         }
     }
 

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/services/FloatingTtsService.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/services/FloatingTtsService.kt
@@ -59,6 +59,7 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
         var paragraphMode by mutableStateOf("tts")
         var ttsHighlightEnabled = mutableStateOf(false)
         var ttsHighlightColor = mutableStateOf("FFFF6D00")
+        var menuHidden = mutableStateOf(false)
         var activityWindowToken: IBinder? = null
 
         private var isExpanded = mutableStateOf(false)
@@ -288,6 +289,7 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
                         showText = showText.value,
                         opacity = opacity.floatValue,
                         onClose = {
+                            menuHidden.value = false
                             isExpanded.value = false
                             val lp = currentLayoutParams ?: return@FloatingTtsOverlayContent
                             lp.width = (32 * displayDensity).toInt()
@@ -305,6 +307,7 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
                         onToggleExpand = {
                             val wasExpanded = isExpanded.value
                             isExpanded.value = !wasExpanded
+                            if (wasExpanded) menuHidden.value = false
                             val lp = currentLayoutParams ?: return@FloatingTtsOverlayContent
                             if (!wasExpanded) {
                                 lp.width = (panelWidth * displayDensity).toInt()
@@ -391,6 +394,10 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
                         },
                         ttsHighlightEnabled = ttsHighlightEnabled.value,
                         ttsHighlightColor = ttsHighlightColor.value,
+                        menuHidden = menuHidden.value,
+                        onToggleMenuHidden = {
+                            menuHidden.value = !menuHidden.value
+                        },
                     )
                 }
             }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/services/FloatingTtsService.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/services/FloatingTtsService.kt
@@ -12,7 +12,6 @@ import android.graphics.PixelFormat
 import android.os.Build
 import android.os.IBinder
 import android.view.Gravity
-import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
 import androidx.compose.runtime.getValue
@@ -114,8 +113,6 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
     private var windowManager: WindowManager? = null
     private var composeView: ComposeView? = null
     private var currentLayoutParams: WindowManager.LayoutParams? = null
-    private var pinchStartDistance = 0f
-    private var pinchStartWidth = 0f
     private var displayDensity = 1f
     private var displayWidth = 0
     private var displayHeight = 0
@@ -238,7 +235,6 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
         positionInitialized.value = true
     }
 
-    @SuppressLint("ClickableViewAccessibility")
     private fun showOverlay() {
         val startPosX = if (isExpanded.value) panelPosX.floatValue else bubblePosX.floatValue
         val startPosY = if (isExpanded.value) panelPosY.floatValue else bubblePosY.floatValue
@@ -265,43 +261,6 @@ internal class FloatingTtsService : Service(), LifecycleOwner, SavedStateRegistr
         composeView = ComposeView(this).apply {
             setViewTreeLifecycleOwner(this@FloatingTtsService)
             setViewTreeSavedStateRegistryOwner(this@FloatingTtsService)
-            setOnTouchListener { _, event ->
-                if (!isExpanded.value) return@setOnTouchListener false
-                when (event.actionMasked) {
-                    MotionEvent.ACTION_POINTER_DOWN -> {
-                        if (event.pointerCount >= 2) {
-                            val x0 = event.getX(0)
-                            val y0 = event.getY(0)
-                            val x1 = event.getX(1)
-                            val y1 = event.getY(1)
-                            pinchStartDistance = Math.hypot((x0 - x1).toDouble(), (y0 - y1).toDouble()).toFloat()
-                            pinchStartWidth = panelWidth
-                        }
-                        false
-                    }
-                    MotionEvent.ACTION_MOVE -> {
-                        if (pinchStartDistance > 0f && event.pointerCount >= 2) {
-                            val x0 = event.getX(0)
-                            val y0 = event.getY(0)
-                            val x1 = event.getX(1)
-                            val y1 = event.getY(1)
-                            val dist = Math.hypot((x0 - x1).toDouble(), (y0 - y1).toDouble()).toFloat()
-                            val scale = dist / pinchStartDistance
-                            val maxW = (displayWidth / displayDensity) - 16f
-                            val newW = (pinchStartWidth * scale).coerceIn(100f, maxW)
-                            handlePanelWidthChange(newW)
-                        }
-                        false
-                    }
-                    MotionEvent.ACTION_POINTER_UP,
-                    MotionEvent.ACTION_UP,
-                    MotionEvent.ACTION_CANCEL -> {
-                        pinchStartDistance = 0f
-                        false
-                    }
-                    else -> false
-                }
-            }
             setContent {
                 val scope = rememberCoroutineScope()
                 val darkModeState = remember { appPreferences.THEME_DARK_MODE.state(scope) }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/FloatingTtsOverlay.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/FloatingTtsOverlay.kt
@@ -43,6 +43,8 @@ internal fun FloatingTtsOverlayContent(
     onParagraphModeChange: ((String) -> Unit)? = null,
     ttsHighlightEnabled: Boolean = false,
     ttsHighlightColor: String = "FFFF6D00",
+    menuHidden: Boolean = false,
+    onToggleMenuHidden: (() -> Unit)? = null,
 ) {
     if (isExpanded) {
         TtsMiniPlayer(
@@ -63,6 +65,8 @@ internal fun FloatingTtsOverlayContent(
             onParagraphModeChange = onParagraphModeChange,
             ttsHighlightEnabled = ttsHighlightEnabled,
             ttsHighlightColor = ttsHighlightColor,
+            menuHidden = menuHidden,
+            onToggleMenuHidden = onToggleMenuHidden,
         )
     } else {
         FloatingBubble(

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/FloatingTtsOverlay.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/FloatingTtsOverlay.kt
@@ -45,6 +45,8 @@ internal fun FloatingTtsOverlayContent(
     ttsHighlightColor: String = "FFFF6D00",
     menuHidden: Boolean = false,
     onToggleMenuHidden: (() -> Unit)? = null,
+    glowActive: Boolean = false,
+    onToggleGlow: (() -> Unit)? = null,
 ) {
     if (isExpanded) {
         TtsMiniPlayer(
@@ -67,6 +69,8 @@ internal fun FloatingTtsOverlayContent(
             ttsHighlightColor = ttsHighlightColor,
             menuHidden = menuHidden,
             onToggleMenuHidden = onToggleMenuHidden,
+            glowActive = glowActive,
+            onToggleGlow = onToggleGlow,
         )
     } else {
         FloatingBubble(

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
@@ -1,11 +1,17 @@
 package my.noveldokusha.features.reader.ui
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -89,6 +95,8 @@ internal fun TtsMiniPlayer(
     onParagraphModeChange: ((String) -> Unit)? = null,
     ttsHighlightEnabled: Boolean = false,
     ttsHighlightColor: String = "FFFF6D00",
+    menuHidden: Boolean = false,
+    onToggleMenuHidden: (() -> Unit)? = null,
 ) {
     FloatingTtsMiniPlayer(
         state = state,
@@ -110,6 +118,8 @@ internal fun TtsMiniPlayer(
         onParagraphModeChange = onParagraphModeChange,
         ttsHighlightEnabled = ttsHighlightEnabled,
         ttsHighlightColor = ttsHighlightColor,
+        menuHidden = menuHidden,
+        onToggleMenuHidden = onToggleMenuHidden,
     )
 }
 
@@ -303,6 +313,8 @@ private fun FloatingTtsMiniPlayer(
     onParagraphModeChange: ((String) -> Unit)? = null,
     ttsHighlightEnabled: Boolean = false,
     ttsHighlightColor: String = "FFFF6D00",
+    menuHidden: Boolean = false,
+    onToggleMenuHidden: (() -> Unit)? = null,
 ) {
     val total = state.estimatedTotalSeconds.value
     val remaining = state.estimatedRemainingSeconds.value
@@ -365,156 +377,164 @@ private fun FloatingTtsMiniPlayer(
         Column(
             modifier = Modifier.padding(8.dp)
         ) {
-            MiniPlayerControls(
-                state = state,
-                onClose = onClose,
-                onStartHere = onStartHere,
-                chapterCurrentNumber = chapterCurrentNumber,
-                chaptersCount = chaptersCount,
-                animatedProgress = animatedProgress,
-                remaining = remaining,
-                buttonSize = buttonSize,
-                iconSize = iconSize,
-                iconCircleSize = iconCircleSize,
-                playButtonSize = playButtonSize,
-                playIconSize = playIconSize,
-                progressHeight = progressHeight,
-                extraAction = {
-                    if (onOpacityChange != null) {
-                        IconButton(
-                            onClick = { showOpacitySlider = !showOpacitySlider },
-                            modifier = Modifier.size(buttonSize)
-                        ) {
-                            Icon(
-                                Icons.Rounded.Tune,
-                                contentDescription = null,
-                                tint = if (showOpacitySlider) MaterialTheme.colorScheme.primary
-                                else MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier
-                                    .size(iconSize)
-                                    .background(MaterialTheme.colorScheme.surfaceContainerHigh, CircleShape),
-                            )
-                        }
-                    }
-                },
-                trailingAction = {
-                    if (onShowTextToggle != null) {
-                        IconButton(
-                            onClick = onShowTextToggle,
-                            modifier = Modifier.size(buttonSize)
-                        ) {
-                            Icon(
-                                Icons.AutoMirrored.Rounded.TextSnippet,
-                                contentDescription = null,
-                                tint = if (showTextToggle) MaterialTheme.colorScheme.primary
-                                else MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier
-                                    .size(iconSize)
-                                    .background(MaterialTheme.colorScheme.surfaceContainerHigh, CircleShape),
-                            )
-                        }
-                    }
-                },
-            )
+            AnimatedVisibility(
+                visible = !menuHidden,
+                enter = fadeIn(tween(200)) + expandVertically(tween(200)),
+                exit = fadeOut(tween(200)) + shrinkVertically(tween(200)),
+            ) {
+                Column {
+                    MiniPlayerControls(
+                        state = state,
+                        onClose = onClose,
+                        onStartHere = onStartHere,
+                        chapterCurrentNumber = chapterCurrentNumber,
+                        chaptersCount = chaptersCount,
+                        animatedProgress = animatedProgress,
+                        remaining = remaining,
+                        buttonSize = buttonSize,
+                        iconSize = iconSize,
+                        iconCircleSize = iconCircleSize,
+                        playButtonSize = playButtonSize,
+                        playIconSize = playIconSize,
+                        progressHeight = progressHeight,
+                        extraAction = {
+                            if (onOpacityChange != null) {
+                                IconButton(
+                                    onClick = { showOpacitySlider = !showOpacitySlider },
+                                    modifier = Modifier.size(buttonSize)
+                                ) {
+                                    Icon(
+                                        Icons.Rounded.Tune,
+                                        contentDescription = null,
+                                        tint = if (showOpacitySlider) MaterialTheme.colorScheme.primary
+                                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier
+                                            .size(iconSize)
+                                            .background(MaterialTheme.colorScheme.surfaceContainerHigh, CircleShape),
+                                    )
+                                }
+                            }
+                        },
+                        trailingAction = {
+                            if (onShowTextToggle != null) {
+                                IconButton(
+                                    onClick = onShowTextToggle,
+                                    modifier = Modifier.size(buttonSize)
+                                ) {
+                                    Icon(
+                                        Icons.AutoMirrored.Rounded.TextSnippet,
+                                        contentDescription = null,
+                                        tint = if (showTextToggle) MaterialTheme.colorScheme.primary
+                                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier
+                                            .size(iconSize)
+                                            .background(MaterialTheme.colorScheme.surfaceContainerHigh, CircleShape),
+                                    )
+                                }
+                            }
+                        },
+                    )
 
-            if (onOpacityChange != null && showOpacitySlider) {
-                Spacer(modifier = Modifier.height(2.dp))
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp),
-                    verticalArrangement = Arrangement.spacedBy(2.dp)
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(
-                            text = stringResource(R.string.tts_floating_opacity),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Slider(
-                            value = opacityValue,
-                            onValueChange = { onOpacityChange(it) },
-                            valueRange = 0.3f..1f,
-                            modifier = Modifier.weight(1f),
-                            colors = SliderDefaults.colors(
-                                thumbColor = MaterialTheme.colorScheme.primary,
-                                activeTrackColor = MaterialTheme.colorScheme.primary,
-                            )
-                        )
-                    }
-                    if (onPanelWidthChange != null) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(
-                            text = stringResource(R.string.tts_floating_width),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                            Spacer(Modifier.width(8.dp))
-                            Slider(
-                                value = panelWidth,
-                                onValueChange = { onPanelWidthChange(it) },
-                                valueRange = minWidth..maxWidth,
-                                modifier = Modifier.weight(1f),
-                                colors = SliderDefaults.colors(
-                                    thumbColor = MaterialTheme.colorScheme.primary,
-                                    activeTrackColor = MaterialTheme.colorScheme.primary,
-                                )
-                            )
-                        }
-                    }
-                    if (onParagraphModeChange != null && state.parallelEnabled.value) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp)
+                    if (onOpacityChange != null && showOpacitySlider) {
+                        Spacer(modifier = Modifier.height(2.dp))
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 4.dp),
+                            verticalArrangement = Arrangement.spacedBy(2.dp)
                         ) {
-                            Text(
-                                text = stringResource(R.string.tts_floating_paragraph),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Spacer(Modifier.width(8.dp))
-                            Text(
-                                text = stringResource(R.string.tts_voice),
-                                color = if (paragraphMode == "tts") MaterialTheme.colorScheme.primary
-                                else MaterialTheme.colorScheme.onSurfaceVariant,
-                                fontWeight = if (paragraphMode == "tts") FontWeight.Bold else FontWeight.Normal,
-                                modifier = Modifier
-                                    .clickable { onParagraphModeChange("tts") }
-                                    .padding(horizontal = 6.dp, vertical = 4.dp),
-                            )
-                            Text(
-                                text = "/",
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Text(
-                                text = stringResource(R.string.tts_both),
-                                color = if (paragraphMode == "both") MaterialTheme.colorScheme.primary
-                                else MaterialTheme.colorScheme.onSurfaceVariant,
-                                fontWeight = if (paragraphMode == "both") FontWeight.Bold else FontWeight.Normal,
-                                modifier = Modifier
-                                    .clickable { onParagraphModeChange("both") }
-                                    .padding(horizontal = 6.dp, vertical = 4.dp),
-                            )
-                            Text(
-                                text = "/",
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Text(
-                                text = stringResource(R.string.inverse),
-                                color = if (paragraphMode == "inverse") MaterialTheme.colorScheme.primary
-                                else MaterialTheme.colorScheme.onSurfaceVariant,
-                                fontWeight = if (paragraphMode == "inverse") FontWeight.Bold else FontWeight.Normal,
-                                modifier = Modifier
-                                    .clickable { onParagraphModeChange("inverse") }
-                                    .padding(horizontal = 6.dp, vertical = 4.dp),
-                            )
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.tts_floating_opacity),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Slider(
+                                    value = opacityValue,
+                                    onValueChange = { onOpacityChange(it) },
+                                    valueRange = 0.3f..1f,
+                                    modifier = Modifier.weight(1f),
+                                    colors = SliderDefaults.colors(
+                                        thumbColor = MaterialTheme.colorScheme.primary,
+                                        activeTrackColor = MaterialTheme.colorScheme.primary,
+                                    )
+                                )
+                            }
+                            if (onPanelWidthChange != null) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.tts_floating_width),
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                    Spacer(Modifier.width(8.dp))
+                                    Slider(
+                                        value = panelWidth,
+                                        onValueChange = { onPanelWidthChange(it) },
+                                        valueRange = minWidth..maxWidth,
+                                        modifier = Modifier.weight(1f),
+                                        colors = SliderDefaults.colors(
+                                            thumbColor = MaterialTheme.colorScheme.primary,
+                                            activeTrackColor = MaterialTheme.colorScheme.primary,
+                                        )
+                                    )
+                                }
+                            }
+                            if (onParagraphModeChange != null && state.parallelEnabled.value) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp)
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.tts_floating_paragraph),
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                    Spacer(Modifier.width(8.dp))
+                                    Text(
+                                        text = stringResource(R.string.tts_voice),
+                                        color = if (paragraphMode == "tts") MaterialTheme.colorScheme.primary
+                                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                                        fontWeight = if (paragraphMode == "tts") FontWeight.Bold else FontWeight.Normal,
+                                        modifier = Modifier
+                                            .clickable { onParagraphModeChange("tts") }
+                                            .padding(horizontal = 6.dp, vertical = 4.dp),
+                                    )
+                                    Text(
+                                        text = "/",
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                    Text(
+                                        text = stringResource(R.string.tts_both),
+                                        color = if (paragraphMode == "both") MaterialTheme.colorScheme.primary
+                                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                                        fontWeight = if (paragraphMode == "both") FontWeight.Bold else FontWeight.Normal,
+                                        modifier = Modifier
+                                            .clickable { onParagraphModeChange("both") }
+                                            .padding(horizontal = 6.dp, vertical = 4.dp),
+                                    )
+                                    Text(
+                                        text = "/",
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                    Text(
+                                        text = stringResource(R.string.inverse),
+                                        color = if (paragraphMode == "inverse") MaterialTheme.colorScheme.primary
+                                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                                        fontWeight = if (paragraphMode == "inverse") FontWeight.Bold else FontWeight.Normal,
+                                        modifier = Modifier
+                                            .clickable { onParagraphModeChange("inverse") }
+                                            .padding(horizontal = 6.dp, vertical = 4.dp),
+                                    )
+                                }
+                            }
                         }
                     }
                 }
@@ -525,7 +545,13 @@ private fun FloatingTtsMiniPlayer(
                 Surface(
                     color = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.5f),
                     shape = RoundedCornerShape(8.dp),
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .pointerInput(Unit) {
+                            detectTapGestures(
+                                onDoubleTap = { onToggleMenuHidden?.invoke() }
+                            )
+                        }
                 ) {
                     if (isBothMode) {
                         val spokenRange = state.spokenWordRange.value

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
@@ -18,7 +18,6 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -381,13 +380,72 @@ private fun FloatingTtsMiniPlayer(
 
     val interactionModifier = if (onDrag != null) {
         Modifier.pointerInput(Unit) {
-            detectDragGestures(
-                onDrag = { change, dragAmount ->
-                    change.consume()
-                    onDrag(dragAmount.x, dragAmount.y)
-                },
-                onDragEnd = { onDragEnd?.invoke() }
-            )
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                down.consume()
+
+                val touchSlop = viewConfiguration.touchSlop
+                var lastPosition = down.position
+                var pinchStartDistance = 0f
+                var pinchStartWidth = panelWidth
+                var isPinching = false
+                var dragStarted = false
+
+                while (true) {
+                    val event = awaitPointerEvent(PointerEventPass.Main)
+                    val changes = event.changes
+                    if (!changes.any { it.pressed }) break
+
+                    val pressed = changes.filter { it.pressed }
+
+                    if (pressed.size >= 2 && onPanelWidthChange != null) {
+                        val p0 = pressed[0].position
+                        val p1 = pressed[1].position
+                        val ddx = p0.x - p1.x
+                        val ddy = p0.y - p1.y
+                        val curDist = Math.hypot(ddx.toDouble(), ddy.toDouble()).toFloat()
+
+                        if (!isPinching) {
+                            isPinching = true
+                            pinchStartDistance = curDist
+                            pinchStartWidth = panelWidth
+                            dragStarted = false
+                        }
+                        if (pinchStartDistance > 0f) {
+                            val scale = curDist / pinchStartDistance
+                            val newW = (pinchStartWidth * scale).coerceIn(minWidth, maxWidth)
+                            onPanelWidthChange.invoke(newW)
+                        }
+                        changes.forEach { it.consume() }
+                    } else if (pressed.size == 1) {
+                        val ch = pressed[0]
+
+                        if (isPinching) {
+                            isPinching = false
+                            dragStarted = false
+                            lastPosition = ch.position
+                            continue
+                        }
+
+                        val dx = ch.position.x - lastPosition.x
+                        val dy = ch.position.y - lastPosition.y
+
+                        if (!dragStarted) {
+                            if (dx * dx + dy * dy > touchSlop * touchSlop) {
+                                dragStarted = true
+                            }
+                        }
+                        if (dragStarted) {
+                            lastPosition = ch.position
+                            ch.consume()
+                            onDrag(dx, dy)
+                        } else {
+                            lastPosition = ch.position
+                        }
+                    }
+                }
+                onDragEnd?.invoke()
+            }
         }
     } else {
         Modifier

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.awaitPointerEvent
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
@@ -54,6 +54,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -351,6 +352,7 @@ private fun FloatingTtsMiniPlayer(
 
     val density = LocalDensity.current
     var showOpacitySlider by remember { mutableStateOf(false) }
+    val currentPanelWidth by rememberUpdatedState(panelWidth)
 
     val infiniteTransition = rememberInfiniteTransition(label = "glow")
     val glowAlpha by infiniteTransition.animateFloat(
@@ -387,12 +389,12 @@ private fun FloatingTtsMiniPlayer(
                 val touchSlop = viewConfiguration.touchSlop
                 var lastPosition = down.position
                 var pinchStartDistance = 0f
-                var pinchStartWidth = panelWidth
+                var pinchStartWidth = currentPanelWidth
                 var isPinching = false
                 var dragStarted = false
 
                 while (true) {
-                    val event = awaitPointerEvent(PointerEventPass.Main)
+                    val event = awaitPointerEvent(PointerEventPass.Initial)
                     val changes = event.changes
                     if (!changes.any { it.pressed }) break
 
@@ -408,7 +410,7 @@ private fun FloatingTtsMiniPlayer(
                         if (!isPinching) {
                             isPinching = true
                             pinchStartDistance = curDist
-                            pinchStartWidth = panelWidth
+                            pinchStartWidth = currentPanelWidth
                             dragStarted = false
                         }
                         if (pinchStartDistance > 0f) {

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
@@ -10,7 +10,9 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitPointerEvent
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -353,15 +355,49 @@ private fun FloatingTtsMiniPlayer(
     val progressHeight = lerpf(3f, 6f, ratio).dp
     val paragraphFontSize = lerpf(9f, 13f, ratio).sp
 
-    val dragModifier = if (onDrag != null) {
+    val interactionModifier = if (onDrag != null) {
         Modifier.pointerInput(Unit) {
-            detectDragGestures(
-                onDrag = { change, dragAmount ->
-                    change.consume()
-                    onDrag(dragAmount.x, dragAmount.y)
-                },
-                onDragEnd = { onDragEnd?.invoke() }
-            )
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                var prevPos = down.position
+                var isPinching = false
+                var initialDistance = 0f
+
+                do {
+                    val event = awaitPointerEvent()
+                    val changes = event.changes.filter { it.pressed }
+
+                    when {
+                        changes.size >= 2 -> {
+                            isPinching = true
+                            val p1 = changes[0].position
+                            val p2 = changes[1].position
+                            val distance = (p1 - p2).getDistance()
+
+                            if (initialDistance == 0f) {
+                                initialDistance = distance
+                            } else if (onPanelWidthChange != null) {
+                                val scale = distance / initialDistance
+                                val newWidth = (panelWidth * scale).coerceIn(minWidth, maxWidth)
+                                onPanelWidthChange(newWidth)
+                                initialDistance = distance
+                            }
+                            changes.forEach { it.consume() }
+                        }
+                        changes.size == 1 && !isPinching -> {
+                            val pos = changes[0].position
+                            val delta = pos - prevPos
+                            onDrag(delta.x, delta.y)
+                            prevPos = pos
+                            changes.forEach { it.consume() }
+                        }
+                    }
+                } while (changes.isNotEmpty())
+
+                if (!isPinching) {
+                    onDragEnd?.invoke()
+                }
+            }
         }
     } else {
         Modifier
@@ -372,7 +408,7 @@ private fun FloatingTtsMiniPlayer(
         color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = opacity),
         shadowElevation = 0.dp,
         modifier = Modifier
-            .then(dragModifier)
+            .then(interactionModifier)
     ) {
         Column(
             modifier = Modifier.padding(8.dp)

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
@@ -2,6 +2,7 @@ package my.noveldokusha.features.reader.ui
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -17,7 +18,6 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.awaitPointerEvent
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/TtsMiniPlayer.kt
@@ -10,9 +10,15 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.awaitPointerEvent
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -57,6 +63,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
@@ -73,6 +80,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.res.stringResource
 import my.noveldokusha.coreui.composableActions.debouncedAction
 import my.noveldokusha.reader.R
+import kotlinx.coroutines.withTimeoutOrNull
 import my.noveldokusha.features.reader.features.TextToSpeechSettingData
 
 @Composable
@@ -98,6 +106,8 @@ internal fun TtsMiniPlayer(
     ttsHighlightColor: String = "FFFF6D00",
     menuHidden: Boolean = false,
     onToggleMenuHidden: (() -> Unit)? = null,
+    glowActive: Boolean = false,
+    onToggleGlow: (() -> Unit)? = null,
 ) {
     FloatingTtsMiniPlayer(
         state = state,
@@ -121,6 +131,8 @@ internal fun TtsMiniPlayer(
         ttsHighlightColor = ttsHighlightColor,
         menuHidden = menuHidden,
         onToggleMenuHidden = onToggleMenuHidden,
+        glowActive = glowActive,
+        onToggleGlow = onToggleGlow,
     )
 }
 
@@ -316,6 +328,8 @@ private fun FloatingTtsMiniPlayer(
     ttsHighlightColor: String = "FFFF6D00",
     menuHidden: Boolean = false,
     onToggleMenuHidden: (() -> Unit)? = null,
+    glowActive: Boolean = false,
+    onToggleGlow: (() -> Unit)? = null,
 ) {
     val total = state.estimatedTotalSeconds.value
     val remaining = state.estimatedRemainingSeconds.value
@@ -339,6 +353,17 @@ private fun FloatingTtsMiniPlayer(
     val density = LocalDensity.current
     var showOpacitySlider by remember { mutableStateOf(false) }
 
+    val infiniteTransition = rememberInfiniteTransition(label = "glow")
+    val glowAlpha by infiniteTransition.animateFloat(
+        initialValue = 0.4f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(800, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "glowAlpha"
+    )
+
     val screenWidthDp = LocalConfiguration.current.screenWidthDp.toFloat()
     val minWidth = 100f
     val maxWidth = screenWidthDp - 16f
@@ -356,47 +381,13 @@ private fun FloatingTtsMiniPlayer(
 
     val interactionModifier = if (onDrag != null) {
         Modifier.pointerInput(Unit) {
-            awaitEachGesture {
-                val down = awaitFirstDown(requireUnconsumed = false)
-                var prevPos = down.position
-                var isPinching = false
-                var initialDistance = 0f
-
-                do {
-                    val event = awaitPointerEvent()
-                    val changes = event.changes.filter { it.pressed }
-
-                    when {
-                        changes.size >= 2 -> {
-                            isPinching = true
-                            val p1 = changes[0].position
-                            val p2 = changes[1].position
-                            val distance = (p1 - p2).getDistance()
-
-                            if (initialDistance == 0f) {
-                                initialDistance = distance
-                            } else if (onPanelWidthChange != null) {
-                                val scale = distance / initialDistance
-                                val newWidth = (panelWidth * scale).coerceIn(minWidth, maxWidth)
-                                onPanelWidthChange(newWidth)
-                                initialDistance = distance
-                            }
-                            changes.forEach { it.consume() }
-                        }
-                        changes.size == 1 && !isPinching -> {
-                            val pos = changes[0].position
-                            val delta = pos - prevPos
-                            onDrag(delta.x, delta.y)
-                            prevPos = pos
-                            changes.forEach { it.consume() }
-                        }
-                    }
-                } while (changes.isNotEmpty())
-
-                if (!isPinching) {
-                    onDragEnd?.invoke()
-                }
-            }
+            detectDragGestures(
+                onDrag = { change, dragAmount ->
+                    change.consume()
+                    onDrag(dragAmount.x, dragAmount.y)
+                },
+                onDragEnd = { onDragEnd?.invoke() }
+            )
         }
     } else {
         Modifier
@@ -582,10 +573,62 @@ private fun FloatingTtsMiniPlayer(
                     shape = RoundedCornerShape(8.dp),
                     modifier = Modifier
                         .fillMaxWidth()
+                        .then(
+                            if (glowActive) {
+                                Modifier.border(
+                                    width = 2.dp,
+                                    color = MaterialTheme.colorScheme.primary.copy(alpha = glowAlpha),
+                                    shape = RoundedCornerShape(8.dp)
+                                )
+                            } else Modifier
+                        )
                         .pointerInput(Unit) {
-                            detectTapGestures(
-                                onDoubleTap = { onToggleMenuHidden?.invoke() }
-                            )
+                            awaitEachGesture {
+                                val down = awaitFirstDown(requireUnconsumed = false)
+                                down.consume()
+
+                                val releasedQuickly = withTimeoutOrNull(300L) {
+                                    while (true) {
+                                        val event = awaitPointerEvent(PointerEventPass.Main)
+                                        if (!event.changes.any { it.id == down.id && it.pressed }) {
+                                            return@withTimeoutOrNull true
+                                        }
+                                    }
+                                    false
+                                }
+
+                                if (releasedQuickly == true) {
+                                    val secondTap = withTimeoutOrNull(300L) {
+                                        while (true) {
+                                            val event = awaitPointerEvent(PointerEventPass.Main)
+                                            val p = event.changes.firstOrNull { it.pressed }
+                                            if (p != null) {
+                                                p.consume()
+                                                return@withTimeoutOrNull true
+                                            }
+                                        }
+                                        false
+                                    }
+                                    if (secondTap == true) {
+                                        onToggleMenuHidden?.invoke()
+                                    }
+                                    return@awaitEachGesture
+                                }
+
+                                val heldToCompletion = withTimeoutOrNull(2000L) {
+                                    while (true) {
+                                        val event = awaitPointerEvent(PointerEventPass.Main)
+                                        if (!event.changes.any { it.id == down.id && it.pressed }) {
+                                            return@withTimeoutOrNull false
+                                        }
+                                    }
+                                    false
+                                }
+
+                                if (heldToCompletion == null) {
+                                    onToggleGlow?.invoke()
+                                }
+                            }
                         }
                 ) {
                     if (isBothMode) {


### PR DESCRIPTION
## Summary

Adds a premium double-tap gesture to the floating TTS overlay that hides/shows the menu controls.

### What it does
- **Double-tap** the paragraph text in the floating TTS overlay → controls (play/pause bar, progress, settings sliders) smoothly hide
- **Double-tap again** → controls come back
- Paragraph text stays visible the whole time
- State resets when overlay collapses back to bubble

### Demo
<p align="center">
  <video src="https://github.com/user-attachments/assets/da684e17-854f-411e-8ef7-e2e509a4181e" controls width="280"></video>
</p>

### How it works
- Wraps `MiniPlayerControls` + settings sliders in `AnimatedVisibility`
- Animation: `fadeIn + expandVertically` / `fadeOut + shrinkVertically` (200ms tween)
- Double-tap detected via `detectTapGestures(onDoubleTap = ...)` on the paragraph text Surface
- `menuHidden` state in `FloatingTtsService.Companion`, reset on collapse/close

### Files changed (3 files, TTS overlay only)
- `FloatingTtsService.kt` — added `menuHidden` state + reset on collapse
- `FloatingTtsOverlay.kt` — passes state through to TtsMiniPlayer
- `TtsMiniPlayer.kt` — `AnimatedVisibility` wrapper, double-tap gesture, no border/glow

### Scope
- Only touches the floating TTS overlay code
- No changes to main reader gestures, TTS logic, scrolling, selection, or any other feature
- Minimal and safe change set
