### PR TITLE
Show Regex Rules in reader as in-page menu panel

### DIFF
--- a/features/reader/build.gradle.kts
+++ b/features/reader/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation(projects.core)
     implementation(projects.coreui)
     implementation(projects.data)
-    implementation(projects.settings)
+    implementation(projects.features.settings)
     implementation(projects.navigation)
     implementation(projects.tooling.localDatabase)
     implementation(projects.tooling.textToSpeech)

--- a/features/reader/build.gradle.kts
+++ b/features/reader/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(projects.core)
     implementation(projects.coreui)
     implementation(projects.data)
+    implementation(projects.settings)
     implementation(projects.navigation)
     implementation(projects.tooling.localDatabase)
     implementation(projects.tooling.textToSpeech)

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
@@ -12,24 +12,16 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -44,7 +36,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
-import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
@@ -65,7 +56,7 @@ import my.noveldokusha.core.utils.Extra_String
 import my.noveldokusha.core.utils.dpToPx
 import my.noveldokusha.core.utils.fadeIn
 import my.noveldokusha.data.AppRepository
-import my.noveldokusha.settings.RegexCleanupSettingsScreen
+import my.noveldokusha.core.models.RegexRule
 import my.noveldokusha.settings.RegexCleanupSettingsViewModel
 import my.noveldokusha.features.reader.domain.ChapterState
 import my.noveldokusha.features.reader.domain.ReaderItem
@@ -76,6 +67,7 @@ import my.noveldokusha.features.reader.manager.ReaderManager
 import my.noveldokusha.features.reader.services.NarratorMediaControlsService
 import my.noveldokusha.features.reader.tools.FontsLoader
 import my.noveldokusha.features.reader.ui.ReaderScreen
+import my.noveldokusha.features.reader.ui.ReaderScreenState
 import my.noveldokusha.features.reader.ui.ReaderViewHandlersActions
 import my.noveldokusha.navigation.NavigationRoutes
 import my.noveldokusha.reader.R
@@ -395,7 +387,36 @@ class ReaderActivity : BaseActivity() {
             }
 
         setContent {
-            var showRegexRulesSheet by remember { mutableStateOf(false) }
+            val regexCleanupViewModel: RegexCleanupSettingsViewModel = viewModel(
+                key = "regexCleanupSettings",
+                factory = viewModelFactory {
+                    initializer {
+                        RegexCleanupSettingsViewModel(
+                            appPreferences = appPreferences,
+                            appRepository = appRepository,
+                            stateHandler = SavedStateHandle(
+                                mapOf("bookUrl" to viewModel.bookUrl)
+                            )
+                        )
+                    }
+                }
+            )
+
+            var regexRulesSnapshot by remember { mutableStateOf<List<RegexRule>>(null) }
+            LaunchedEffect(viewModel.state.settings.selectedSetting.value) {
+                val selected = viewModel.state.settings.selectedSetting.value
+                if (selected == ReaderScreenState.Settings.Type.RegexRules) {
+                    regexRulesSnapshot = appPreferences.effectiveRegexRules(viewModel.bookUrl)
+                } else {
+                    val before = regexRulesSnapshot
+                    regexRulesSnapshot = null
+                    if (before != null &&
+                        before != appPreferences.effectiveRegexRules(viewModel.bookUrl)
+                    ) {
+                        viewModel.reloadReader()
+                    }
+                }
+            }
 
             Theme(themeProvider) {
                 readerTheme {
@@ -426,9 +447,7 @@ class ReaderActivity : BaseActivity() {
                             navigationRoutes.webView(this, url = url).let(::startActivity)
                         }
                     },
-                    onRegexRulesClick = {
-                        showRegexRulesSheet = true
-                    },
+                    regexCleanupViewModel = regexCleanupViewModel,
                     readerContent = {
                         AndroidView(factory = { viewBind.root })
                     },
@@ -439,49 +458,6 @@ class ReaderActivity : BaseActivity() {
                             viewModel.state.showInvalidChapterDialog.value = false
                         }) {
                             Text(stringResource(id = R.string.invalid_chapter))
-                        }
-                    }
-
-                    if (showRegexRulesSheet) {
-                        val regexCleanupViewModel: RegexCleanupSettingsViewModel = viewModel(
-                            key = "regexCleanupSettings",
-                            factory = viewModelFactory {
-                                initializer {
-                                    RegexCleanupSettingsViewModel(
-                                        appPreferences = appPreferences,
-                                        appRepository = appRepository,
-                                        stateHandler = SavedStateHandle(
-                                            mapOf("bookUrl" to viewModel.bookUrl)
-                                        )
-                                    )
-                                }
-                            }
-                        )
-                        val sheetHeight =
-                            (LocalConfiguration.current.screenHeightDp / 2f).roundToInt().dp
-
-                        ModalBottomSheet(
-                            onDismissRequest = {
-                                showRegexRulesSheet = false
-                                viewModel.reloadReader()
-                            },
-                            sheetState = rememberModalBottomSheetState(
-                                skipPartiallyExpanded = true
-                            ),
-                            shape = RoundedCornerShape(topStart = 22.dp, topEnd = 22.dp),
-                            containerColor = MaterialTheme.colorScheme.background,
-                        ) {
-                            RegexCleanupSettingsScreen(
-                                viewModel = regexCleanupViewModel,
-                                onNavigateBack = {
-                                    showRegexRulesSheet = false
-                                    viewModel.reloadReader()
-                                },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(sheetHeight),
-                                applyStatusBarPadding = false,
-                            )
                         }
                     }
                 }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
@@ -402,7 +402,7 @@ class ReaderActivity : BaseActivity() {
                 }
             )
 
-            var regexRulesSnapshot by remember { mutableStateOf<List<RegexRule>>(null) }
+            var regexRulesSnapshot by remember { mutableStateOf<List<RegexRule>?>(null) }
             LaunchedEffect(viewModel.state.settings.selectedSetting.value) {
                 val selected = viewModel.state.settings.selectedSetting.value
                 if (selected == ReaderScreenState.Settings.Type.RegexRules) {

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
@@ -11,23 +11,40 @@ import android.widget.AbsListView
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.OnBackPressedCallback
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.doOnNextLayout
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
@@ -47,6 +64,9 @@ import my.noveldokusha.core.utils.Extra_Boolean
 import my.noveldokusha.core.utils.Extra_String
 import my.noveldokusha.core.utils.dpToPx
 import my.noveldokusha.core.utils.fadeIn
+import my.noveldokusha.data.AppRepository
+import my.noveldokusha.settings.RegexCleanupSettingsScreen
+import my.noveldokusha.settings.RegexCleanupSettingsViewModel
 import my.noveldokusha.features.reader.domain.ChapterState
 import my.noveldokusha.features.reader.domain.ReaderItem
 import my.noveldokusha.features.reader.domain.ReaderItemAdapter
@@ -98,6 +118,9 @@ class ReaderActivity : BaseActivity() {
     @Inject
     internal lateinit var readerManager: ReaderManager
 
+    @Inject
+    internal lateinit var appRepository: AppRepository
+
     private var listIsScrolling = false
     // Время последнего события скролла: используется как watchdog для сброса
     // «залипшего» listIsScrolling, если fling был прерван (notifyDataSetChanged
@@ -124,14 +147,6 @@ class ReaderActivity : BaseActivity() {
     private val doubleTapThresholdMs = 350L
 
     private val viewModel by viewModels<ReaderViewModel>()
-
-    // Возврат из редактора регэксп-правил: перезагружаем текущую главу,
-    // чтобы персональные правила применились к тексту.
-    private val regexRulesLauncher = registerForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) {
-        viewModel.reloadReader()
-    }
 
     private val viewBind by lazy { ActivityReaderBinding.inflate(layoutInflater) }
     private val viewAdapter = object {
@@ -380,6 +395,8 @@ class ReaderActivity : BaseActivity() {
             }
 
         setContent {
+            var showRegexRulesSheet by remember { mutableStateOf(false) }
+
             Theme(themeProvider) {
                 readerTheme {
                     SetSystemBarTransparent()
@@ -410,8 +427,7 @@ class ReaderActivity : BaseActivity() {
                         }
                     },
                     onRegexRulesClick = {
-                        navigationRoutes.regexRules(this, viewModel.bookUrl)
-                            .let(regexRulesLauncher::launch)
+                        showRegexRulesSheet = true
                     },
                     readerContent = {
                         AndroidView(factory = { viewBind.root })
@@ -423,6 +439,49 @@ class ReaderActivity : BaseActivity() {
                             viewModel.state.showInvalidChapterDialog.value = false
                         }) {
                             Text(stringResource(id = R.string.invalid_chapter))
+                        }
+                    }
+
+                    if (showRegexRulesSheet) {
+                        val regexCleanupViewModel: RegexCleanupSettingsViewModel = viewModel(
+                            key = "regexCleanupSettings",
+                            factory = viewModelFactory {
+                                initializer {
+                                    RegexCleanupSettingsViewModel(
+                                        appPreferences = appPreferences,
+                                        appRepository = appRepository,
+                                        stateHandler = SavedStateHandle(
+                                            mapOf("bookUrl" to viewModel.bookUrl)
+                                        )
+                                    )
+                                }
+                            }
+                        )
+                        val sheetHeight =
+                            (LocalConfiguration.current.screenHeightDp / 2f).roundToInt().dp
+
+                        ModalBottomSheet(
+                            onDismissRequest = {
+                                showRegexRulesSheet = false
+                                viewModel.reloadReader()
+                            },
+                            sheetState = rememberModalBottomSheetState(
+                                skipPartiallyExpanded = true
+                            ),
+                            shape = RoundedCornerShape(topStart = 22.dp, topEnd = 22.dp),
+                            containerColor = MaterialTheme.colorScheme.background,
+                        ) {
+                            RegexCleanupSettingsScreen(
+                                viewModel = regexCleanupViewModel,
+                                onNavigateBack = {
+                                    showRegexRulesSheet = false
+                                    viewModel.reloadReader()
+                                },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(sheetHeight),
+                                applyStatusBarPadding = false,
+                            )
                         }
                     }
                 }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderChaptersLoader.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderChaptersLoader.kt
@@ -24,6 +24,7 @@ import my.noveldokusha.features.reader.domain.ReaderItem
 import my.noveldokusha.features.reader.domain.ReaderState
 import my.noveldokusha.features.reader.domain.ReadingChapterPosStats
 import my.noveldokusha.features.reader.domain.indexOfReaderItem
+import my.noveldokusha.features.reader.tools.applyUserRegexRules
 import my.noveldokusha.features.reader.tools.textToItemsConverter
 import my.noveldokusha.features.reader.ui.ReaderViewHandlersActions
 import my.noveldokusha.feature.local_database.DAOs.ChapterTranslationDao
@@ -788,6 +789,20 @@ internal class ReaderChaptersLoader(
 
                 val finalItemTitle = itemTitle.copy(textTranslated = titleTranslated)
 
+                // Apply regex cleanup to the translated text too, just like the
+                // original text. Only real translations are cleaned: fallbacks to
+                // the already-cleaned original (textTranslated == text) are skipped
+                // to avoid applying the same rule twice.
+                val regexRules = regexRulesProvider()
+                val itemsCleaned = items.map { item ->
+                    if (item is ReaderItem.Body) {
+                        val translated = item.textTranslated
+                        if (translated != null && translated != item.text) {
+                            item.copy(textTranslated = applyUserRegexRules(translated, regexRules))
+                        } else item
+                    } else item
+                }
+
                 // Do NOT use maintainPosition for success block — it would call
                 // setSelection(titleIndex) via doMaintainStartPosition and override
                 // the scroll position set by setInitialPosition later.
@@ -802,7 +817,7 @@ internal class ReaderChaptersLoader(
                             if (idx != -1) this@ReaderChaptersLoader.items[idx] = finalItemTitle
                         }
                         itemTranslationAttribution?.let { insert(it) }
-                        insertAll(items)
+                        insertAll(itemsCleaned)
                         insert(ReaderItem.Divider(chapterIndex = chapterIndex))
                         readerViewHandlersActions.doForceUpdateListViewState()
                     }
@@ -814,7 +829,7 @@ internal class ReaderChaptersLoader(
                         val idx = backingList.indexOf(itemTitle)
                         if (idx != -1) backingList[idx] = finalItemTitle
                         itemTranslationAttribution?.let { backingList.add(it) }
-                        backingList.addAll(items)
+                        backingList.addAll(itemsCleaned)
                         backingList.add(ReaderItem.Divider(chapterIndex = chapterIndex))
                         readerViewHandlersActions.forceUpdateListViewState?.invoke()
                     }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/tools/TextToItemsConverter.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/tools/TextToItemsConverter.kt
@@ -266,7 +266,7 @@ private fun countUnbalancedBrackets(str: String, open: Set<Char>, close: Set<Cha
 
 private fun countQuotes(str: String, quotes: Set<Char>): Int = str.count { it in quotes }
 
-private fun applyUserRegexRules(text: String, rules: List<RegexRule>): String {
+internal fun applyUserRegexRules(text: String, rules: List<RegexRule>): String {
     var result = text
     rules.filter { it.isEnabled }.forEach { rule ->
         try {

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreen.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreen.kt
@@ -83,6 +83,7 @@ import my.noveldokusha.features.reader.features.TextSynthesis
 import my.noveldokusha.features.reader.features.TextToSpeechSettingData
 import my.noveldokusha.features.reader.ui.ReaderScreenState.Settings.Type
 import my.noveldokusha.reader.R
+import my.noveldokusha.settings.RegexCleanupSettingsViewModel
 import my.noveldokusha.text_to_speech.Utterance
 import my.noveldokusha.text_to_speech.VoiceData
 import my.noveldokusha.features.reader.services.FloatingTtsService
@@ -106,7 +107,7 @@ internal fun ReaderScreen(
     onParagraphSpacingChanged: (Float) -> Unit,
     onPressBack: () -> Unit,
     onOpenChapterInWeb: () -> Unit,
-    onRegexRulesClick: () -> Unit,
+    regexCleanupViewModel: RegexCleanupSettingsViewModel? = null,
     onTtsHighlightEnabledChange: (Boolean) -> Unit,
     onTtsHighlightColorChange: (String) -> Unit,
     readerContent: @Composable (paddingValues: PaddingValues) -> Unit,
@@ -194,8 +195,8 @@ internal fun ReaderScreen(
                                 IconButton(onClick = { toggleOrSet(Type.Style) }, modifier = Modifier.size(36.dp)) {
                                     Icon(Icons.Outlined.ColorLens, stringResource(R.string.style), modifier = Modifier.size(20.dp), tint = if (selectedSetting == Type.Style) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface)
                                 }
-                                IconButton(onClick = onRegexRulesClick, modifier = Modifier.size(36.dp)) {
-                                    Icon(Icons.Outlined.Rule, stringResource(R.string.regex_cleanup_novel_rules), modifier = Modifier.size(20.dp))
+                                IconButton(onClick = { toggleOrSet(Type.RegexRules) }, modifier = Modifier.size(36.dp)) {
+                                    Icon(Icons.Outlined.Rule, stringResource(R.string.regex_cleanup_novel_rules), modifier = Modifier.size(20.dp), tint = if (selectedSetting == Type.RegexRules) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface)
                                 }
                                 IconButton(onClick = { toggleOrSet(Type.More) }, modifier = Modifier.size(36.dp)) {
                                     Icon(Icons.Filled.Build, stringResource(R.string.more), modifier = Modifier.size(20.dp), tint = if (selectedSetting == Type.More) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface)
@@ -220,6 +221,7 @@ internal fun ReaderScreen(
                 Column {
                     ReaderScreenBottomBarDialogs(
                         settings = state.settings,
+                        regexCleanupViewModel = regexCleanupViewModel,
                         onTextFontChanged = onTextFontChanged,
                         onTextSizeChanged = onTextSizeChanged,
                         onLineHeightChanged = onLineHeightChanged,
@@ -577,7 +579,6 @@ private fun ViewsPreview(
                 onAppThemeChanged = {},
                 onPressBack = {},
                 onOpenChapterInWeb = {},
-                onRegexRulesClick = {},
                 readerContent = {},
                 onKeepScreenOn = {},
                 onFullScreen = {},

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreenBottomBarDialogs.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreenBottomBarDialogs.kt
@@ -5,20 +5,26 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
 import my.noveldokusha.coreui.theme.AppTheme
 import my.noveldokusha.coreui.theme.DarkMode
 import my.noveldokusha.features.reader.ui.settingDialogs.MoreSettingDialog
 import my.noveldokusha.features.reader.ui.settingDialogs.StyleSettingDialog
 import my.noveldokusha.features.reader.ui.settingDialogs.TranslatorSettingDialog
 import my.noveldokusha.features.reader.ui.settingDialogs.VoiceReaderSettingDialog
+import my.noveldokusha.settings.RegexCleanupSettingsScreen
+import my.noveldokusha.settings.RegexCleanupSettingsViewModel
 
 @Composable
 internal fun ReaderScreenBottomBarDialogs(
     settings: ReaderScreenState.Settings,
+    regexCleanupViewModel: RegexCleanupSettingsViewModel?,
     onTextFontChanged: (String) -> Unit,
     onTextSizeChanged: (Float) -> Unit,
     onLineHeightChanged: (Float) -> Unit,
@@ -74,6 +80,24 @@ internal fun ReaderScreenBottomBarDialogs(
                         onTtsHighlightColorChange = onTtsHighlightColorChange,
                     )
                     ReaderScreenState.Settings.Type.None -> Unit
+                    ReaderScreenState.Settings.Type.RegexRules -> {
+                        val viewModel = regexCleanupViewModel
+                        if (viewModel != null) {
+                            val panelHeight =
+                                (LocalConfiguration.current.screenHeightDp * 0.6f).roundToInt().dp
+                            RegexCleanupSettingsScreen(
+                                viewModel = viewModel,
+                                onNavigateBack = {
+                                    settings.selectedSetting.value =
+                                        ReaderScreenState.Settings.Type.None
+                                },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(panelHeight),
+                                applyStatusBarPadding = false,
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreenState.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreenState.kt
@@ -63,7 +63,7 @@ internal data class ReaderScreenState(
 
         @Immutable
         enum class Type {
-            None, LiveTranslation, TextToSpeech, Style, More
+            None, LiveTranslation, TextToSpeech, Style, More, RegexRules
         }
     }
 }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/settingDialogs/VoiceReaderSettingDialog.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/settingDialogs/VoiceReaderSettingDialog.kt
@@ -8,12 +8,12 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.automirrored.rounded.NavigateNext
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.CenterFocusStrong
 import androidx.compose.material.icons.filled.CenterFocusWeak
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.RecordVoiceOver
 import androidx.compose.material.icons.filled.StarRate
 import androidx.compose.material.icons.outlined.Save
@@ -56,7 +57,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -102,7 +102,6 @@ import my.noveldokusha.reader.R
 import my.noveldokusha.text_to_speech.VoiceData
 
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun VoiceReaderSettingDialog(
     state: TextToSpeechSettingData,
@@ -158,9 +157,10 @@ internal fun VoiceReaderSettingDialog(
                     onValueChangeFinished = { state.setVoiceSpeed(localSpeed) },
                 )
 
-                FlowRow(
+                Row(
                     horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.horizontalScroll(rememberScrollState()),
                 ) {
                     AssistChip(
                         label = { Text(text = stringResource(id = R.string.start_here)) },
@@ -252,47 +252,27 @@ internal fun VoiceReaderSettingDialog(
                 }
 
                 if (floatingTtsState != null) {
-                    Surface(
-                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                        shape = RoundedCornerShape(12.dp),
-                        modifier = Modifier.fillMaxWidth()
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center
                     ) {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 12.dp, vertical = 8.dp)
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.horizontalScroll(rememberScrollState()),
                         ) {
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.tts_floating),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    fontWeight = FontWeight.SemiBold
-                                )
-                                Switch(
-                                    checked = floatingTtsState.isEnabled.value,
-                                    onCheckedChange = { floatingTtsState.isEnabled.value = it }
-                                )
-                            }
-                            HorizontalDivider()
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.tts_floating_show_outside_app),
-                                    style = MaterialTheme.typography.bodyMedium
-                                )
-                                Switch(
-                                    checked = floatingTtsState.showOutsideApp.value,
-                                    onCheckedChange = { floatingTtsState.showOutsideApp.value = it },
-                                    enabled = floatingTtsState.isEnabled.value
-                                )
-                            }
+                            FloatingTtsToggleCard(
+                                text = stringResource(R.string.tts_floating),
+                                checked = floatingTtsState.isEnabled.value,
+                                enabled = true,
+                                onToggle = { floatingTtsState.isEnabled.value = !floatingTtsState.isEnabled.value },
+                            )
+                            FloatingTtsToggleCard(
+                                text = stringResource(R.string.tts_floating_show_outside_app),
+                                checked = floatingTtsState.showOutsideApp.value,
+                                enabled = floatingTtsState.isEnabled.value,
+                                onToggle = { floatingTtsState.showOutsideApp.value = !floatingTtsState.showOutsideApp.value },
+                            )
                         }
                     }
                 }
@@ -387,8 +367,45 @@ internal fun VoiceReaderSettingDialog(
                 }
             }
         }
+    }
+}
 
-
+@Composable
+private fun FloatingTtsToggleCard(
+    text: String,
+    checked: Boolean,
+    enabled: Boolean,
+    onToggle: () -> Unit,
+) {
+    Surface(
+        onClick = onToggle,
+        enabled = enabled,
+        shape = RoundedCornerShape(50),
+        color = if (checked) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerHigh
+        },
+        modifier = Modifier.heightIn(min = 30.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+        ) {
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            if (checked) {
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                )
+            }
+        }
     }
 }
 

--- a/features/settings/src/main/java/my/noveldokusha/settings/RegexCleanupSettingsScreen.kt
+++ b/features/settings/src/main/java/my/noveldokusha/settings/RegexCleanupSettingsScreen.kt
@@ -41,7 +41,8 @@ import my.noveldokusha.core.models.RegexRule
 fun RegexCleanupSettingsScreen(
     viewModel: RegexCleanupSettingsViewModel,
     onNavigateBack: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    applyStatusBarPadding: Boolean = true
 ) {
     val state by viewModel.uiState
     val filteredRules = viewModel.filteredRules
@@ -50,7 +51,7 @@ fun RegexCleanupSettingsScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .statusBarsPadding()
+            .then(if (applyStatusBarPadding) Modifier.statusBarsPadding() else Modifier)
             .background(MaterialTheme.colorScheme.background)
     ) {
         // ── TopBar ─────────────────────────────────────────────────────────

--- a/features/settings/src/main/java/my/noveldokusha/settings/RegexCleanupSettingsScreen.kt
+++ b/features/settings/src/main/java/my/noveldokusha/settings/RegexCleanupSettingsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -16,6 +17,7 @@ import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.Rule
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -65,7 +67,7 @@ fun RegexCleanupSettingsScreen(
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp)
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 IconButton(
                     onClick = onNavigateBack,
@@ -77,15 +79,23 @@ fun RegexCleanupSettingsScreen(
                         tint = MaterialTheme.colorScheme.onBackground
                     )
                 }
-                Text(
-                    text = stringResource(
-                        id = if (viewModel.isGlobal) R.string.regex_cleanup_title
-                        else R.string.regex_cleanup_novel_rules
-                    ),
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.onBackground,
-                    fontWeight = FontWeight.Medium
-                )
+                Surface(
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(32.dp)
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            imageVector = Icons.Outlined.Rule,
+                            contentDescription = stringResource(
+                                id = if (viewModel.isGlobal) R.string.regex_cleanup_title
+                                else R.string.regex_cleanup_novel_rules
+                            ),
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                }
             }
 
             Surface(


### PR DESCRIPTION
# 🎯 Summary

**Regex Rules** now opens inside the reader as a **smooth, in-page panel**  — exactly like the Translator, TTS, Style and More menus — instead of a separate bottom-sheet dialog or the full-screen `RegexRulesActivity`.

It also fixes two annoying issues from the earlier bottom-sheet approach:

-  **No more blink** — the panel lives *inside* the reader window (no dialog window flicker)
- **No more TTS interruption** — opening/closing the panel no longer stops or resets the reader's speech

---

# ❌ The problem (before)

| 😖 Symptom | 🔍 Root cause |
|---|---|
| 👀 Visible **blink** on open/close | The panel was a `ModalBottomSheet` — a *separate dialog window* rendered on top of the immersive, edge-to-edge reader window. Every open/close created/destroyed it, flickering the system bars. |
| ⏹️ **TTS stopped/reset** on close | Closing called `reloadReader()` → `readerTextToSpeech.stop()` + full chapter restart — **even when nothing was edited**. |
| 🚪 Full-screen navigation | The original flow launched the entire `RegexRulesActivity`, yanking the user away from reading. |

# ✅ The fix (after)

| ✨ What | 🔧 How |
|---|---|
| 🔄 Expands / collapses **in place** | Regex Rules is now a new `Type.RegexRules` entry in the reader's `selectedSetting` menu state, rendered inline in the bottom panel (height-capped at **60%** of the screen). |
| 👌 **No blink** | No dialog window — the panel is a regular composable inside the reader window, animated with the same `AnimatedContent` used by the other menus. |
| 🔊 **TTS keeps playing** | Opening/closing the panel does **nothing** unless rules were actually changed. |
| 💾 Rules **still apply** | The reader reloads **only when the effective rules changed** while the panel was open — so edited text updates without interrupting an idle reader. |

---

# 🔧 What changed

| 📁 File | 🔨 Change |
|---|---|
| `features/reader/ui/ReaderScreenState.kt` | ➕ Added `RegexRules` to the `Type` enum used by the reader's `selectedSetting` menu state. |
| `features/reader/ui/ReaderScreen.kt` | 🖱️ The Regex Rules icon now *toggles* the new menu type via `toggleOrSet(Type.RegexRules)`, with the same active-color highlight as the other menu icons. |
| `features/reader/ui/ReaderScreenBottomBarDialogs.kt` | 🧩 Renders the existing `RegexCleanupSettingsScreen` inline for the `RegexRules` type (height-capped at 60% of the screen). |
| `features/reader/ReaderActivity.kt` | 🗑️ Removed the `ModalBottomSheet`; the `RegexCleanupSettingsViewModel` is created **once** and passed down; added **reload-on-change** logic. |
| `features/reader/features/ReaderChaptersLoader.kt` + `features/reader/tools/TextToItemsConverter.kt` | 🌐 Regex cleanup now also applies to **translated** chapter text — body paragraphs from batch / MLKit / cache get the same cleanup as the original text. Raw translations are cached unchanged; cleanup happens at display time. |
| `features/reader/build.gradle.kts` | ➕ Added `implementation(projects.settings)` so the reader can reuse the Regex Rules composable. |
| `features/settings/RegexCleanupSettingsScreen.kt` | 🎛️ Added an optional `applyStatusBarPadding` (default `true`) for the in-page panel, and replaced the bulky header title text with a **compact circular logo badge** 🏷️ (Rule icon on a `primaryContainer` chip). The Settings → Regex Rules screen keeps all functionality. |

---

# 🎮 Behavior

- ✅ **Seamless open/close** — expands and collapses like the Translator / TTS / Style / More menus
- ✅ **No blink** — the panel stays inside the reader window
- ✅ **No TTS stop** on plain open/close — speech keeps playing
- ✅ **Instant persistence** — every edit is saved to preferences immediately
- ✅ **Applied on close** — if rules actually changed, the reader reloads so the cleaned text shows (same as the old return-from-activity behavior)
- ✅ **Translated chapters** — regex cleanup also applies to the translated output, so the same rules work on both normal and translated text

# 🧪 Verification

- [x] GitHub Actions build (`buildRelease.yml`, **test** mode) — ✅ **passed**
- [x] APK artifact: `NoveLA-v1.4.0-test` 📦
- [x] Latest run: [Build APK (test)](https://github.com/Vaizer0/NoveLA/actions/runs/30941190575)
- [x] PR is mergeable into `default` ✅

# 📝 Notes

- 🚫 **No changes** to Settings, navigation, or any other reader behavior
- 🔒 **No redesign** of the Regex Rules UI — search, add / edit / delete / move / toggle, preview and validation are all untouched
- 🏷️ The header title text was swapped for a compact, premium logo badge only — a small visual tweak, nothing functional
- 🎨 Panel height (60%) is easily tunable in `ReaderScreenBottomBarDialogs.kt`
