### PR TITLE
Make translation language pair per-novel

### DIFF
--- a/core/src/main/java/my/noveldokusha/core/appPreferences/AppPreferences.kt
+++ b/core/src/main/java/my/noveldokusha/core/appPreferences/AppPreferences.kt
@@ -40,6 +40,12 @@ data class NovelPromptData(
     val appendMode: Boolean = false,
 )
 
+@Serializable
+data class TranslationLangPair(
+    val source: String = "",
+    val target: String = "",
+)
+
 @Singleton
 class AppPreferences @Inject constructor(
     @ApplicationContext val context: Context,
@@ -329,6 +335,74 @@ class AppPreferences @Inject constructor(
         object : Preference<String>("GLOBAL_TRANSLATION_PREFERRED_TARGET") {
             override var value by SharedPreference_String(name, preferences, "")
         }
+
+    // Персональная языковая пара для новелл: Map<bookUrl, TranslationLangPair>.
+    // Новелла без явной настройки наследует глобальную пару
+    // (GLOBAL_TRANSLATION_PREFERRED_SOURCE / GLOBAL_TRANSLATION_PREFERRED_TARGET).
+    val TRANSLATION_BOOK_LANG_PAIR =
+        object : Preference<Map<String, TranslationLangPair>>("TRANSLATION_BOOK_LANG_PAIR") {
+            override var value by SharedPreference_Serializable<Map<String, TranslationLangPair>>(
+                name = name,
+                sharedPreferences = preferences,
+                defaultValue = emptyMap(),
+                encode = { map ->
+                    val obj = org.json.JSONObject()
+                    map.forEach { (url, pair) ->
+                        obj.put(
+                            url,
+                            org.json.JSONObject().apply {
+                                put("source", pair.source)
+                                put("target", pair.target)
+                            }
+                        )
+                    }
+                    obj.toString()
+                },
+                decode = { raw ->
+                    try {
+                        val obj = org.json.JSONObject(raw)
+                        val result = mutableMapOf<String, TranslationLangPair>()
+                        for (key in obj.keys()) {
+                            val value = obj.get(key)
+                            result[key] = when (value) {
+                                is org.json.JSONObject -> TranslationLangPair(
+                                    source = value.optString("source", ""),
+                                    target = value.optString("target", ""),
+                                )
+                                else -> TranslationLangPair()
+                            }
+                        }
+                        result
+                    } catch (_: Exception) { emptyMap() }
+                }
+            )
+        }
+
+    fun translationPairForBook(bookUrl: String): TranslationLangPair {
+        val stored = TRANSLATION_BOOK_LANG_PAIR.value[bookUrl]
+        if (stored != null) return stored
+        return TranslationLangPair(
+            source = GLOBAL_TRANSLATION_PREFERRED_SOURCE.value,
+            target = GLOBAL_TRANSLATION_PREFERRED_TARGET.value,
+        )
+    }
+
+    fun translationSourceForBook(bookUrl: String): String =
+        translationPairForBook(bookUrl).source
+
+    fun translationTargetForBook(bookUrl: String): String =
+        translationPairForBook(bookUrl).target
+
+    fun setTranslationPairForBook(bookUrl: String, source: String, target: String) {
+        if (bookUrl.isBlank()) {
+            GLOBAL_TRANSLATION_PREFERRED_SOURCE.value = source
+            GLOBAL_TRANSLATION_PREFERRED_TARGET.value = target
+            return
+        }
+        val current = TRANSLATION_BOOK_LANG_PAIR.value.toMutableMap()
+        current[bookUrl] = TranslationLangPair(source = source, target = target)
+        TRANSLATION_BOOK_LANG_PAIR.value = current
+    }
 
     val GLOBAL_APP_UPDATER_CHECKER_ENABLED =
         object : Preference<Boolean>("GLOBAL_APP_UPDATER_CHECKER_ENABLED") {

--- a/data/src/main/java/my/noveldokusha/data/DownloadManager.kt
+++ b/data/src/main/java/my/noveldokusha/data/DownloadManager.kt
@@ -396,8 +396,9 @@ class DownloadManager @Inject constructor(
         // Фильтруем главы до lock — IO-операция
         val toProcess = withContext(Dispatchers.IO) {
             if (translateMode) {
-                val sourceLang = appPreferences.GLOBAL_TRANSLATION_PREFERRED_SOURCE.value
-                val targetLang = appPreferences.GLOBAL_TRANSLATION_PREFERRED_TARGET.value
+                val pair = appPreferences.translationPairForBook(bookUrl)
+                val sourceLang = pair.source
+                val targetLang = pair.target
                 if (!appPreferences.translationEnabledForBook(bookUrl) || sourceLang.isBlank() || targetLang.isBlank()) {
                     emptyList()
                 } else {
@@ -633,8 +634,9 @@ class DownloadManager @Inject constructor(
                     // Перевод делает сетевой запрос, поэтому между главами есть пауза.
                     val cachedBody = chapterBodyRepository.getCachedBody(chapterUrl)
                     if (cachedBody != null) {
-                        val sourceLang = appPreferences.GLOBAL_TRANSLATION_PREFERRED_SOURCE.value
-                        val targetLang = appPreferences.GLOBAL_TRANSLATION_PREFERRED_TARGET.value
+                        val pair = appPreferences.translationPairForBook(bookUrl)
+                        val sourceLang = pair.source
+                        val targetLang = pair.target
                         val needsTranslation = appPreferences.translationEnabledForBook(bookUrl) &&
                             sourceLang.isNotBlank() && targetLang.isNotBlank() &&
                             (chapterTranslationDao.getTranslations(chapterUrl, sourceLang, targetLang)
@@ -1007,8 +1009,9 @@ class DownloadManager @Inject constructor(
      * [TranslateOutcome.Failure] с признаком сетевой ошибки — для ожидания сети.
      */
     private suspend fun translateAndSave(bookUrl: String, chapterUrl: String, body: String): TranslateOutcome {
-        val sourceLang = appPreferences.GLOBAL_TRANSLATION_PREFERRED_SOURCE.value
-        val targetLang = appPreferences.GLOBAL_TRANSLATION_PREFERRED_TARGET.value
+        val pair = appPreferences.translationPairForBook(bookUrl)
+        val sourceLang = pair.source
+        val targetLang = pair.target
         val isEnabled = appPreferences.translationEnabledForBook(bookUrl)
         if (!isEnabled || sourceLang.isBlank() || targetLang.isBlank()) {
             Timber.d("translation skipped (enabled=$isEnabled)")

--- a/features/chaptersList/src/main/java/my/noveldokusha/features/chapterslist/ChaptersViewModel.kt
+++ b/features/chaptersList/src/main/java/my/noveldokusha/features/chapterslist/ChaptersViewModel.kt
@@ -133,7 +133,7 @@ internal class ChaptersViewModel @Inject constructor(
     fun translateBookInfo() {
         if (isTranslatingInfo.value) return
         viewModelScope.launch {
-            val targetLang = appPreferences.GLOBAL_TRANSLATION_PREFERRED_TARGET.value
+            val targetLang = appPreferences.translationTargetForBook(bookUrl)
             if (targetLang.isBlank()) {
                 toasty.show(R.string.translate_target_lang_not_set)
                 return@launch
@@ -232,9 +232,12 @@ internal class ChaptersViewModel @Inject constructor(
                 bookUrlFlow,
                 appPreferences.TRANSLATION_BOOK_ENABLED.flow(),
                 appPreferences.GLOBAL_TRANSLATION_ENABLED.flow(),
-                appPreferences.GLOBAL_TRANSLATION_PREFERRED_TARGET.flow()
-            ) { url, bookEnabled, globalEnabled, targetLang ->
-                (bookEnabled[url] ?: globalEnabled) to targetLang
+                appPreferences.GLOBAL_TRANSLATION_PREFERRED_TARGET.flow(),
+                appPreferences.TRANSLATION_BOOK_LANG_PAIR.flow()
+            ) { url, bookEnabled, globalEnabled, globalTarget, bookPairs ->
+                val enabled = bookEnabled[url] ?: globalEnabled
+                val target = bookPairs[url]?.target ?: globalTarget
+                enabled to target
             }
                 .flatMapLatest { (enabled, targetLang) ->
                     if (enabled) {
@@ -611,8 +614,9 @@ internal class ChaptersViewModel @Inject constructor(
     fun translateSelected() {
         if (state.isLocalSource.value) return
 
-        val sourceLang = appPreferences.GLOBAL_TRANSLATION_PREFERRED_SOURCE.value
-        val targetLang = appPreferences.GLOBAL_TRANSLATION_PREFERRED_TARGET.value
+        val pair = appPreferences.translationPairForBook(bookUrl)
+        val sourceLang = pair.source
+        val targetLang = pair.target
         if (!appPreferences.translationEnabledForBook(bookUrl) || sourceLang.isBlank() || targetLang.isBlank()) {
             toasty.show(R.string.translation_not_configured)
             return

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderLiveTranslation.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderLiveTranslation.kt
@@ -102,8 +102,9 @@ internal class ReaderLiveTranslation(
 
     suspend fun init() {
         Timber.d("init: starting")
-        val source = appPreferences.GLOBAL_TRANSLATION_PREFERRED_SOURCE.value
-        val target = appPreferences.GLOBAL_TRANSLATION_PREFERRED_TARGET.value
+        val pair = appPreferences.translationPairForBook(bookUrl)
+        val source = pair.source
+        val target = pair.target
         Timber.d("init: source=$source, target=$target")
         Timber.d("init: translationAvailable=${translationManager.available}")
 
@@ -194,7 +195,11 @@ internal class ReaderLiveTranslation(
         Timber.d("onSourceChange: ${it?.language}")
         try {
             state.source.value = it
-            appPreferences.GLOBAL_TRANSLATION_PREFERRED_SOURCE.value = it?.language ?: ""
+            appPreferences.setTranslationPairForBook(
+                bookUrl = bookUrl,
+                source = it?.language ?: "",
+                target = appPreferences.translationTargetForBook(bookUrl),
+            )
             val update = updateTranslatorState()
             Timber.d("onSourceChange: updateRequired=$update")
             if (update) scope.launch {
@@ -210,7 +215,11 @@ internal class ReaderLiveTranslation(
         Timber.d("onTargetChange: ${it?.language}")
         try {
             state.target.value = it
-            appPreferences.GLOBAL_TRANSLATION_PREFERRED_TARGET.value = it?.language ?: ""
+            appPreferences.setTranslationPairForBook(
+                bookUrl = bookUrl,
+                source = appPreferences.translationSourceForBook(bookUrl),
+                target = it?.language ?: "",
+            )
             val update = updateTranslatorState()
             Timber.d("onTargetChange: updateRequired=$update")
             if (update) scope.launch {


### PR DESCRIPTION
## Overview

> **Feature:** Translation language pair is now remembered **per novel**, instead of globally shared across all novels.

Follow-up to the per-novel translation *enabled* state (#126). That change made the on/off switch novel-specific, but the selected **source → target language pair** was still stored globally. This PR makes it per-novel.

---

## ❌ The Problem

The translation source/target pair was stored in two *global* preferences, so changing it in one novel silently changed it for **every** novel.

### Reproduce

1. Open **Novel A**, set translation to **Chinese → English**.
2. Open **Novel B**, change translation to **Arabic → English**.
3. Go back to **Novel A** — its translation is now also **Arabic → English**.

---

## ✅ The Fix

Each novel **independently remembers** its own source and target language.

| Novel | Language pair | Affected by other novels? |
|-------|---------------|---------------------------|
| **Novel A** | Chinese → English | No |
| **Novel B** | Arabic → English | No |
| **Novel C** | Japanese → English | No |

- Changing a pair in one novel never touches another novel.
- Reopening a novel restores the last pair used for that novel.
- Novels never customized fall back to the **global default pair** — fully backwards compatible, no existing settings are lost.

---

## 🧠 How it works

### Storage

New preference in `AppPreferences`:

```
TRANSLATION_BOOK_LANG_PAIR = Map<bookUrl, TranslationLangPair(source, target)>
```

JSON-serialized with the same defensive pattern as `TRANSLATION_NOVEL_PROMPTS` (corrupt/legacy data decodes to an empty map — no crash risk).

### Resolution (fallback chain)

```
pairForBook(bookUrl):
  stored per-novel pair ?  → use it
  else                      → use global GLOBAL_TRANSLATION_PREFERRED_SOURCE / _TARGET
```

First pair change **inside** a novel pins that novel's own pair; the global prefs remain the default for untouched novels.

### New `AppPreferences` API

| Function | Purpose |
|----------|---------|
| `translationPairForBook(bookUrl)` | Effective pair (stored → global fallback) |
| `translationSourceForBook(bookUrl)` | Effective source half |
| `translationTargetForBook(bookUrl)` | Effective target half |
| `setTranslationPairForBook(url, source, target)` | Save a pair (blank url → writes globals, mirroring `setTranslationEnabledForBook`) |

---

## 🔧 Files changed

| File | What changed |
|------|--------------|
| `core/.../appPreferences/AppPreferences.kt` | `TranslationLangPair` + `TRANSLATION_BOOK_LANG_PAIR` preference + 4 helpers |
| `features/reader/.../features/ReaderLiveTranslation.kt` | Reader loads the novel's effective pair; in-reader dialog writes only that novel's pair |
| `data/.../DownloadManager.kt` | Download-and-translate path uses the novel's pair (enqueue filter, cached-chapter worker, `translateAndSave`) |
| `features/chaptersList/.../ChaptersViewModel.kt` | Book-info translation, translated chapter titles, translate-selected use the novel's pair |

> DownloadManager/ChaptersViewModel are included because they consume the same pair — otherwise downloading or translating a novel's chapters could still use another novel's pair.

---

## 🧪 Verification

- [x] **Build passes** — GitHub Actions test build succeeded on the fork at commit `05c59987` ([run #30956237357](https://github.com/Vaizer0/NoveLA/actions/runs/30956237357))
- [x] **Mergeable** — PR is mergeable with no conflicts
- [x] **No unrelated changes** — translation enable state, provider, novel prompts, parallel mode untouched
- [x] **No fork-specific changes** — this branch contains no `applicationId` modification (`my.novela.vaizer0` is not present)
