### PR TITLE
fix(reader): suspend TTS auto-scroll on manual scroll until Focus

### DIFF
--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
@@ -507,6 +507,12 @@ class ReaderActivity : BaseActivity() {
                         scrollState == AbsListView.OnScrollListener.SCROLL_STATE_TOUCH_SCROLL
                     ) {
                         userHasScrolled = true
+                    }
+                    // Programmatic smoothScrollToPosition* тоже отдаёт FLING (а не только
+                    // жест пользователя), поэтому follow отключаем ТОЛЬКО по TOUCH_SCROLL:
+                    // это состояние возникает исключительно при касании пальца, когда
+                    // палец ещё на экране, и не бывает при programmatic-скролле.
+                    if (scrollState == AbsListView.OnScrollListener.SCROLL_STATE_TOUCH_SCROLL) {
                         followScrollEnabled = false
                     }
                     // When the user lifts their finger, check if we need to load more chapters

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
@@ -133,6 +133,9 @@ class ReaderActivity : BaseActivity() {
     // Сбрасывается в false при каждом открытии Activity, устанавливается в true только при
     // TOUCH_SCROLL или FLING — т.е. при реальном жесте, не при programmatic setSelectionFromTop.
     private var userHasScrolled = false
+    // Ручной скролл приостанавливает follow-скролл за TTS-абзацем до нажатия
+    // кнопки «Фокус» (или навигации по абзацам), чтобы экран не перехватывался.
+    private var followScrollEnabled = true
 
     // Double-tap detection for showing/hiding reader info
     private var lastTapTime = 0L
@@ -312,6 +315,9 @@ class ReaderActivity : BaseActivity() {
 
         viewModel.readerSpeaker.scrollToReaderItem.asLiveData().observe(this) {
             if (it !is ReaderItem.Position) return@observe
+            // «Фокус» и переходы по абзацам — явное действие пользователя:
+            // возобновляем follow-скролл.
+            followScrollEnabled = true
             scrollToReadingPositionForced(
                 chapterIndex = it.chapterIndex,
                 chapterItemPosition = it.chapterItemPosition,
@@ -501,6 +507,7 @@ class ReaderActivity : BaseActivity() {
                         scrollState == AbsListView.OnScrollListener.SCROLL_STATE_TOUCH_SCROLL
                     ) {
                         userHasScrolled = true
+                        followScrollEnabled = false
                     }
                     // When the user lifts their finger, check if we need to load more chapters
                     if (!listIsScrolling) {
@@ -628,6 +635,11 @@ class ReaderActivity : BaseActivity() {
             lastReboundChapterItemPosition = chapterItemPosition
             lastReboundPlayState = playState
             viewAdapter.listView.notifyDataSetChanged()
+        }
+
+        // Ручной скролл приостанавливает follow-скролл до кнопки «Фокус».
+        if (!followScrollEnabled) {
+            return
         }
 
         // If user is scrolling, don't auto-scroll


### PR DESCRIPTION
## 🎯 Summary
TTS auto-scroll used to fight manual scrolling — the screen kept yanking back to the spoken paragraph. This PR makes a manual scroll **stick**: auto-follow suspends until you tap **Focus** (or TTS **prev/next**), then resumes normally.

**Fix:** ~18 lines, 1 file, no redesign.

---

## 🐛 Problem → 🎯 Goal

| # | Behavior | Before | After |
|:-:|:--|:-:|:-:|
| 1 | Auto-scroll follows the spoken paragraph | ✅ | ✅ |
| 2 | Manual scroll suspends auto-scroll (no snap-back) | ❌ | ✅ |
| 3 | **Focus** / TTS prev-next resumes auto-scroll | 〰️ | ✅ |

---

## ⚙️ Solution

**Gate flag** `followScrollEnabled` in `ReaderActivity`:
- `true` (default) → auto-follow works exactly as before.
- `false` → `scrollToReadingPositionOptional()` skips the scroll (highlight still updates).

**Turned off only on a real touch-scroll:**

| Scroll state | Meaning | Fired by programmatic scrolls? |
|:--|:--|:-:|
| `TOUCH_SCROLL` | finger dragging on the screen | ❌ **No — we trust this** |
| `FLING` | momentum coasting to a stop | ✅ Yes ⚠️ unreliable |

> ⚠️ `FLING` also fires for the app's own `smoothScrollToPositionFromTop()` (auto-follow, onResume restore, Focus). The first version used it and broke auto-scroll from the start — caught in device testing.

**Turned on** by the `scrollToReaderItem` observer (**Focus** + TTS **prev/next**) right before its forced scroll.

---

## 📝 Files changed

| File | Change |
|:--|:--|
| `features/reader/.../ReaderActivity.kt` | gate flag + early-return guard (only file) |

---

## 🧪 Verification

- ✅ CI `buildRelease.yml` (`build_type: test`) passes — workflow untouched
- ✅ Static re-trace of the 3 behaviors above
- 🧑 Device test recommended before merge

---

## 📦 APK

| | |
|:--|:--|
| Latest successful run | [Run #31045899099](https://github.com/Vaizer0/NoveLA/actions/runs/31045899099) |
| Artifact | [`NoveLA-v1.4.0-test`](https://github.com/Vaizer0/NoveLA/actions/runs/31045899099/artifacts/8946635944) |

> ℹ️ Artifact download requires GitHub sign-in.

---

## 🚫 Out of scope
TTS playback, highlighting, translation, chapter loading, and the gesture system — all untouched.
