### PR TITLE
feat: store translation toggle and language pair independently per novel

### DIFF
--- a/core/src/main/java/my/noveldokusha/core/appPreferences/AppPreferences.kt
+++ b/core/src/main/java/my/noveldokusha/core/appPreferences/AppPreferences.kt
@@ -79,14 +79,31 @@ internal fun decodeTranslationPairMap(raw: String): Map<String, TranslationLangP
         result
     } catch (_: Exception) { emptyMap() }
 
-// Персональный режим: новелла включена только при наличии полной пары.
+internal fun encodeEnabledMap(map: Map<String, Boolean>): String {
+    val obj = org.json.JSONObject()
+    map.forEach { (url, enabled) -> obj.put(url, enabled) }
+    return obj.toString()
+}
+
+internal fun decodeEnabledMap(raw: String): Map<String, Boolean> =
+    try {
+        val obj = org.json.JSONObject(raw)
+        val result = mutableMapOf<String, Boolean>()
+        for (key in obj.keys()) {
+            result[key] = obj.optBoolean(key, false)
+        }
+        result
+    } catch (_: Exception) { emptyMap() }
+
+// Персональный режим: новелла включена собственным переключателем
+// (TRANSLATION_BOOK_ENABLED_MAP), независимым от пары языков.
 fun resolveTranslationEnabled(
     globalMode: Boolean,
     globalEnabled: Boolean,
-    map: Map<String, TranslationLangPair>,
+    enabledMap: Map<String, Boolean>,
     bookUrl: String,
 ): Boolean =
-    if (globalMode) globalEnabled else map[bookUrl]?.isComplete == true
+    if (globalMode) globalEnabled else enabledMap[bookUrl] == true
 
 internal fun resolveTranslationPair(
     globalMode: Boolean,
@@ -98,7 +115,9 @@ internal fun resolveTranslationPair(
     if (globalMode) TranslationLangPair(source = globalSource, target = globalTarget)
     else map[bookUrl] ?: TranslationLangPair()
 
-// Персональный режим: частичная пара удаляется — новелла выключается (unpin).
+// Персональный режим: пара сохраняется даже частичной — она не равна
+// выключению перевода (переключатель хранится отдельно).
+// Запись удаляется только когда оба языка пустые.
 internal fun updateTranslationPairMap(
     map: Map<String, TranslationLangPair>,
     bookUrl: String,
@@ -106,13 +125,18 @@ internal fun updateTranslationPairMap(
     target: String,
 ): Map<String, TranslationLangPair> {
     val current = map.toMutableMap()
-    if (source.isBlank() || target.isBlank()) {
+    if (source.isBlank() && target.isBlank()) {
         current.remove(bookUrl)
     } else {
         current[bookUrl] = TranslationLangPair(source = source, target = target)
     }
     return current
 }
+
+// Миграция: «включено» раньше означало наличие полной пары в персональной карте.
+// Переносим это состояние в отдельный переключатель TRANSLATION_BOOK_ENABLED_MAP.
+internal fun deriveEnabledMapFromPairs(pairs: Map<String, TranslationLangPair>): Map<String, Boolean> =
+    pairs.filterValues { it.isComplete }.mapValues { true }
 
 // Миграция старого тумблера TRANSLATION_BOOK_ENABLED (JSON Map<bookUrl, Boolean>):
 // «включено без собственной пары» раньше означало перевод по глобальной паре —
@@ -411,11 +435,25 @@ class AppPreferences @Inject constructor(
             )
         }
 
+    // Персональный переключатель перевода новеллы: Map<bookUrl, Boolean>.
+    // Хранится отдельно от TRANSLATION_BOOK_LANG_PAIR: выбор пары не включает перевод,
+    // выключение перевода не удаляет пару. Отсутствие ключа = перевод выключен.
+    val TRANSLATION_BOOK_ENABLED_MAP =
+        object : Preference<Map<String, Boolean>>("TRANSLATION_BOOK_ENABLED_MAP") {
+            override var value by SharedPreference_Serializable<Map<String, Boolean>>(
+                name = name,
+                sharedPreferences = preferences,
+                defaultValue = emptyMap(),
+                encode = { encodeEnabledMap(it) },
+                decode = { decodeEnabledMap(it) }
+            )
+        }
+
     fun translationEnabledForBook(bookUrl: String): Boolean =
         resolveTranslationEnabled(
             globalMode = TRANSLATION_GLOBAL_MODE.value,
             globalEnabled = GLOBAL_TRANSLATION_ENABLED.value,
-            map = TRANSLATION_BOOK_LANG_PAIR.value,
+            enabledMap = TRANSLATION_BOOK_ENABLED_MAP.value,
             bookUrl = bookUrl,
         )
 
@@ -448,12 +486,17 @@ class AppPreferences @Inject constructor(
         )
     }
 
-    // Выключает перевод конкретной новеллы (персональный режим).
-    fun clearTranslationPairForBook(bookUrl: String) {
-        val current = TRANSLATION_BOOK_LANG_PAIR.value.toMutableMap()
-        if (current.remove(bookUrl) != null) {
-            TRANSLATION_BOOK_LANG_PAIR.value = current
+    // Включает/выключает перевод конкретной новеллы (персональный режим).
+    // Пару языков не трогает — она остаётся сохранённой и восстанавливается
+    // при повторном включении.
+    fun setTranslationEnabledForBook(bookUrl: String, enabled: Boolean) {
+        if (TRANSLATION_GLOBAL_MODE.value) {
+            GLOBAL_TRANSLATION_ENABLED.value = enabled
+            return
         }
+        val current = TRANSLATION_BOOK_ENABLED_MAP.value.toMutableMap()
+        if (enabled) current[bookUrl] = true else current.remove(bookUrl)
+        TRANSLATION_BOOK_ENABLED_MAP.value = current
     }
 
     // Миграция настроек перевода, сделанных до объединения enabled+pair в единую карту.
@@ -462,6 +505,15 @@ class AppPreferences @Inject constructor(
     // Выполняется один раз: наличие TRANSLATION_GLOBAL_MODE означает, что миграция завершена.
     init {
         migrateLegacyTranslationSettings()
+        migrateEnabledStateFromPairs()
+    }
+
+    // Миграция (один раз): новеллы с полной парой в TRANSLATION_BOOK_LANG_PAIR
+    // получают enabled=true в новом переключателе TRANSLATION_BOOK_ENABLED_MAP —
+    // сохраняем прежнее поведение («есть пара = перевод включён»).
+    private fun migrateEnabledStateFromPairs() {
+        if (preferences.contains("TRANSLATION_BOOK_ENABLED_MAP")) return
+        TRANSLATION_BOOK_ENABLED_MAP.value = deriveEnabledMapFromPairs(TRANSLATION_BOOK_LANG_PAIR.value)
     }
 
     private fun migrateLegacyTranslationSettings() {

--- a/core/src/test/java/my/noveldokusha/core/appPreferences/TranslationLangPairTest.kt
+++ b/core/src/test/java/my/noveldokusha/core/appPreferences/TranslationLangPairTest.kt
@@ -51,37 +51,39 @@ class TranslationLangPairTest {
     // ─── Per-novel mode semantics ───────────────────────────────────────────
 
     @Test
-    fun `per-novel mode off by default without a full pair`() {
-        val empty = emptyMap<String, TranslationLangPair>()
+    fun `per-novel mode off by default`() {
+        val enabledMap = emptyMap<String, Boolean>()
 
-        assertFalse(resolveTranslationEnabled(false, globalEnabled = true, map = empty, bookUrl = "a"))
-        assertEquals(TranslationLangPair(), resolveTranslationPair(false, "en", "ru", empty, "a"))
+        assertFalse(resolveTranslationEnabled(false, globalEnabled = true, enabledMap = enabledMap, bookUrl = "a"))
+        assertEquals(TranslationLangPair(), resolveTranslationPair(false, "en", "ru", emptyMap(), "a"))
     }
 
     @Test
-    fun `partial pair is not enabled in per-novel mode`() {
-        val map = mapOf("a" to TranslationLangPair(source = "en"))
+    fun `per-novel mode enabled only when flag present`() {
+        val enabledMap = mapOf("a" to true)
 
-        assertFalse(resolveTranslationEnabled(false, globalEnabled = true, map = map, bookUrl = "a"))
+        assertTrue(resolveTranslationEnabled(false, globalEnabled = false, enabledMap = enabledMap, bookUrl = "a"))
+        assertFalse(resolveTranslationEnabled(false, globalEnabled = false, enabledMap = enabledMap, bookUrl = "b"))
     }
 
     @Test
-    fun `full pair enables the novel in per-novel mode`() {
-        val map = mapOf("a" to TranslationLangPair(source = "en", target = "ru"))
+    fun `full pair does not enable - toggle decides`() {
+        val pairs = mapOf("a" to TranslationLangPair(source = "en", target = "ru"))
+        val enabledMap = emptyMap<String, Boolean>()
 
-        assertTrue(resolveTranslationEnabled(false, globalEnabled = false, map = map, bookUrl = "a"))
-        assertEquals(TranslationLangPair("en", "ru"), resolveTranslationPair(false, "en", "ru", map, "a"))
+        assertFalse(resolveTranslationEnabled(false, globalEnabled = true, enabledMap = enabledMap, bookUrl = "a"))
+        assertEquals(TranslationLangPair("en", "ru"), resolveTranslationPair(false, "en", "ru", pairs, "a"))
     }
 
     @Test
-    fun `global mode ignores per-novel map`() {
-        val map = mapOf("a" to TranslationLangPair(source = "en", target = "ru"))
+    fun `global mode ignores per-novel enabled map`() {
+        val enabledMap = mapOf("a" to false)
 
-        assertTrue(resolveTranslationEnabled(true, globalEnabled = true, map = map, bookUrl = "other"))
-        assertFalse(resolveTranslationEnabled(true, globalEnabled = false, map = map, bookUrl = "a"))
+        assertTrue(resolveTranslationEnabled(true, globalEnabled = true, enabledMap = enabledMap, bookUrl = "a"))
+        assertFalse(resolveTranslationEnabled(true, globalEnabled = false, enabledMap = enabledMap, bookUrl = "a"))
         assertEquals(
             TranslationLangPair(source = "fr", target = "de"),
-            resolveTranslationPair(true, "fr", "de", map, "a"),
+            resolveTranslationPair(true, "fr", "de", emptyMap(), "a"),
         )
     }
 
@@ -95,14 +97,71 @@ class TranslationLangPairTest {
     }
 
     @Test
-    fun `writing partial pair removes entry (unpin)`() {
+    fun `writing partial pair keeps entry`() {
         val initial = mapOf("a" to TranslationLangPair("en", "ru"))
 
         val updated = updateTranslationPairMap(initial, bookUrl = "a", source = "", target = "ru")
         val updated2 = updateTranslationPairMap(initial, bookUrl = "a", source = "en", target = "")
 
+        assertEquals(TranslationLangPair("", "ru"), updated["a"])
+        assertEquals(TranslationLangPair("en", ""), updated2["a"])
+    }
+
+    @Test
+    fun `writing empty pair removes entry`() {
+        val initial = mapOf("a" to TranslationLangPair("en", "ru"))
+
+        val updated = updateTranslationPairMap(initial, bookUrl = "a", source = "", target = "")
+
         assertTrue(updated.isEmpty())
-        assertTrue(updated2.isEmpty())
+    }
+
+    // ─── Enabled map codec ──────────────────────────────────────────────────
+
+    @Test
+    fun `enabled map codec roundtrip preserves map`() {
+        val map = mapOf(
+            "https://example.com/a" to true,
+            "local://Книга" to false,
+        )
+
+        val decoded = decodeEnabledMap(encodeEnabledMap(map))
+
+        assertEquals(map, decoded)
+    }
+
+    @Test
+    fun `enabled map decode of corrupt json returns empty map`() {
+        assertTrue(decodeEnabledMap("not json at all {").isEmpty())
+        assertTrue(decodeEnabledMap("").isEmpty())
+        assertTrue(decodeEnabledMap("[]").isEmpty())
+    }
+
+    @Test
+    fun `enabled map decode treats missing or non-bool values as false`() {
+        val decoded = decodeEnabledMap("""{"a": true, "b": "yes", "c": 1}""")
+
+        assertEquals(true, decoded["a"])
+        assertEquals(false, decoded["b"])
+        assertEquals(false, decoded["c"])
+    }
+
+    // ─── Enabled state migration (pairs -> toggle map) ──────────────────────
+
+    @Test
+    fun `migration derives enabled from complete pairs only`() {
+        val pairs = mapOf(
+            "a" to TranslationLangPair("en", "ru"),
+            "b" to TranslationLangPair("en"),
+            "c" to TranslationLangPair(),
+        )
+
+        assertEquals(mapOf("a" to true), deriveEnabledMapFromPairs(pairs))
+    }
+
+    @Test
+    fun `migration from empty pairs gives empty enabled map`() {
+        assertTrue(deriveEnabledMapFromPairs(emptyMap()).isEmpty())
     }
 
     // ─── Legacy migration (TRANSLATION_BOOK_ENABLED) ─────────────────────────

--- a/features/chaptersList/src/main/java/my/noveldokusha/features/chapterslist/ChaptersViewModel.kt
+++ b/features/chaptersList/src/main/java/my/noveldokusha/features/chapterslist/ChaptersViewModel.kt
@@ -230,13 +230,16 @@ internal class ChaptersViewModel @Inject constructor(
         // Подписываемся на переведённые названия глав из БД
         viewModelScope.launch {
             combine(
-                bookUrlFlow,
+                combine(
+                    bookUrlFlow,
+                    appPreferences.TRANSLATION_BOOK_ENABLED_MAP.flow(),
+                ) { url, bookEnabled -> url to bookEnabled },
                 appPreferences.TRANSLATION_BOOK_LANG_PAIR.flow(),
                 appPreferences.GLOBAL_TRANSLATION_ENABLED.flow(),
                 appPreferences.GLOBAL_TRANSLATION_PREFERRED_TARGET.flow(),
                 appPreferences.TRANSLATION_GLOBAL_MODE.flow()
-            ) { url, bookPairs, globalEnabled, globalTarget, globalMode ->
-                val enabled = resolveTranslationEnabled(globalMode, globalEnabled, bookPairs, url)
+            ) { (url, bookEnabled), bookPairs, globalEnabled, globalTarget, globalMode ->
+                val enabled = resolveTranslationEnabled(globalMode, globalEnabled, bookEnabled, url)
                 val target = if (globalMode) globalTarget else bookPairs[url]?.target ?: ""
                 enabled to target
             }

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderLiveTranslation.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/features/ReaderLiveTranslation.kt
@@ -47,7 +47,6 @@ internal data class LiveTranslationSettingData(
     val onParallelOrderChange: (String) -> Unit,
     val translationGlobalMode: MutableState<Boolean>,
     val onTranslationGlobalModeChange: (Boolean) -> Unit,
-    val onUnpinBook: () -> Unit,
 )
 
 internal class ReaderLiveTranslation(
@@ -94,7 +93,6 @@ internal class ReaderLiveTranslation(
         onParallelOrderChange = ::onParallelOrderChange,
         translationGlobalMode = mutableStateOf(appPreferences.TRANSLATION_GLOBAL_MODE.value),
         onTranslationGlobalModeChange = ::onTranslationGlobalModeChange,
-        onUnpinBook = ::onUnpinBook,
     )
 
     var translatorState: TranslatorState? = null
@@ -187,20 +185,20 @@ internal class ReaderLiveTranslation(
     private fun onEnable(it: Boolean) {
         Timber.d("onEnable: $it")
         try {
-            when {
-                // Глобальный режим: единый переключатель для всех новелл.
-                appPreferences.TRANSLATION_GLOBAL_MODE.value -> {
-                    state.enable.value = it
-                    appPreferences.GLOBAL_TRANSLATION_ENABLED.value = it
-                    val update = updateTranslatorState()
-                    Timber.d("onEnable: updateRequired=$update")
-                    if (update) scope.launch {
-                        _onTranslatorChanged.emit(Unit)
-                    }
-                }
-                // Персональный режим: включение возможно только выбором полной пары.
-                !it -> onUnpinBook()
-                else -> Timber.d("onEnable: per-novel mode, no-op (pair required)")
+            // Глобальный режим: единый переключатель для всех новелл.
+            if (appPreferences.TRANSLATION_GLOBAL_MODE.value) {
+                state.enable.value = it
+                appPreferences.GLOBAL_TRANSLATION_ENABLED.value = it
+            } else {
+                // Персональный режим: переключатель независим от пары языков.
+                // Выключение не удаляет пару — при повторном включении она восстановится.
+                state.enable.value = it
+                appPreferences.setTranslationEnabledForBook(bookUrl, it)
+            }
+            val update = updateTranslatorState()
+            Timber.d("onEnable: updateRequired=$update")
+            if (update) scope.launch {
+                _onTranslatorChanged.emit(Unit)
             }
         } catch (e: Exception) {
             Timber.e(e, "onEnable: error")
@@ -217,7 +215,6 @@ internal class ReaderLiveTranslation(
                 source = it?.language ?: "",
                 target = state.target.value?.language ?: "",
             )
-            state.enable.value = appPreferences.translationEnabledForBook(bookUrl)
             val update = updateTranslatorState()
             Timber.d("onSourceChange: updateRequired=$update")
             if (update) scope.launch {
@@ -238,7 +235,6 @@ internal class ReaderLiveTranslation(
                 source = state.source.value?.language ?: "",
                 target = it?.language ?: "",
             )
-            state.enable.value = appPreferences.translationEnabledForBook(bookUrl)
             val update = updateTranslatorState()
             Timber.d("onTargetChange: updateRequired=$update")
             if (update) scope.launch {
@@ -264,18 +260,6 @@ internal class ReaderLiveTranslation(
         } catch (e: Exception) {
             Timber.e(e, "onTranslationGlobalModeChange: error")
             throw e
-        }
-    }
-
-    private fun onUnpinBook() {
-        Timber.d("onUnpinBook")
-        appPreferences.clearTranslationPairForBook(bookUrl)
-        state.source.value = null
-        state.target.value = null
-        state.enable.value = false
-        val update = updateTranslatorState()
-        if (update) scope.launch {
-            _onTranslatorChanged.emit(Unit)
         }
     }
 

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreen.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/ReaderScreen.kt
@@ -474,7 +474,6 @@ private fun ViewsPreview(
         onParallelOrderChange = {},
         translationGlobalMode = remember { mutableStateOf(false) },
         onTranslationGlobalModeChange = {},
-        onUnpinBook = {},
     )
 
     val textToSpeechSettingData = TextToSpeechSettingData(

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ui/settingDialogs/TranslatorSettingDialog.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ui/settingDialogs/TranslatorSettingDialog.kt
@@ -83,7 +83,7 @@ internal fun TranslatorSettingDialog(
             ) {
                 Switch(
                     checked = state.enable.value,
-                    enabled = state.translationGlobalMode.value || state.enable.value,
+                    enabled = true,
                     onCheckedChange = { state.onEnable(it) },
                     colors = SwitchDefaults.colors(
                         checkedThumbColor = colorAccent(),
@@ -117,14 +117,20 @@ internal fun TranslatorSettingDialog(
                 ModeToggle(state = state)
             }
 
-            // ── Подсказка включения: в персональном режиме перевод включается
-            // только выбором обоих языков, поэтому выключенный switch нужно пояснить.
-            if (!state.translationGlobalMode.value && !state.enable.value) {
-                Text(
-                    text = stringResource(R.string.translation_select_pair_to_enable),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+            // ── Подсказка состояния: переключатель и пара независимы. ──
+            when {
+                !state.translationGlobalMode.value && !state.enable.value ->
+                    Text(
+                        text = stringResource(R.string.translation_toggle_off_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                !state.translationGlobalMode.value && (state.source.value == null || state.target.value == null) ->
+                    Text(
+                        text = stringResource(R.string.translation_select_pair_to_enable),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
             }
 
             // ── Provider selection ──────────────────────────────────────

--- a/strings/src/main/res/values-ru/strings.xml
+++ b/strings/src/main/res/values-ru/strings.xml
@@ -253,7 +253,8 @@
     <string name="translation_mode_per_novel">Эта новелла</string>
 
     <string name="translation_mode_global">Все новеллы</string>
-    <string name="translation_select_pair_to_enable">Выберите язык источника и перевода, чтобы включить перевод</string>
+    <string name="translation_select_pair_to_enable">Выберите язык источника и перевода, чтобы начать перевод</string>
+    <string name="translation_toggle_off_hint">Перевод выключен для этой новеллы. Включите его, чтобы переводить.</string>
 
     <string name="creating_backup">Создание резервной копии</string>
 

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -135,7 +135,8 @@
     <string name="translation_mode_settings_description">Per-novel language pair, or one pair for all novels</string>
     <string name="translation_mode_per_novel">This novel</string>
     <string name="translation_mode_global">All novels</string>
-    <string name="translation_select_pair_to_enable">Select source and target languages to enable translation</string>
+    <string name="translation_select_pair_to_enable">Select source and target languages to start translating</string>
+    <string name="translation_toggle_off_hint">Translation is off for this novel. Turn it on to translate.</string>
     <string name="provider_name">Provider: %s</string>
     <string name="language_selection">Language</string>
     <string name="language_search">Select language</string>


### PR DESCRIPTION
Fixes #131

## Summary

The per-novel translation **toggle** and the per-novel translation **language pair** are now stored and handled independently:

- Selecting a language pair no longer automatically enables translation for the novel, and toggling translation off no longer wipes the saved pair.
- The toggle is a free, per-novel switch; translated titles in the chapters list follow the same independent toggle.
- The translation dialog shows clear state hints so the user always knows whether translation is enabled and for which pair.

## Changes

| File | Change |
| --- | --- |
| `core/appPreferences/AppPreferences.kt` | Store the translation toggle independently from the language pair; unit-tested |
| `core/appPreferences/TranslationLangPairTest.kt` | Tests for independent toggle/pair storage |
| `features/chapterslist/ChaptersViewModel.kt` | Translated titles respect the independent per-novel toggle |
| `features/reader/features/ReaderLiveTranslation.kt` | Toggle and pair lookups decoupled |
| `features/reader/ui/ReaderScreen.kt` | Removed dead coupling |
| `features/reader/ui/settingDialogs/TranslatorSettingDialog.kt` | Free toggle + state hints |
| `strings` (values + values-ru) | New UI strings |

## Behavior

- **Before:** picking a pair forced translation on; toggling translation off discarded the pair.
- **After:** toggle and pair are independent. Toggle stays off until the user turns it on; the selected pair persists across toggles.
