### PR TITLE
fix(reader): pause TTS auto-scroll only when the current paragraph is off-screen

### DIFF
--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
@@ -507,6 +507,12 @@ class ReaderActivity : BaseActivity() {
                         scrollState == AbsListView.OnScrollListener.SCROLL_STATE_TOUCH_SCROLL
                     ) {
                         userHasScrolled = true
+                    }
+                    // Programmatic smoothScrollToPosition* тоже отдаёт FLING (а не только
+                    // жест пользователя), поэтому follow отключаем ТОЛЬКО по TOUCH_SCROLL:
+                    // это состояние возникает исключительно при касании пальца, когда
+                    // палец ещё на экране, и не бывает при programmatic-скролле.
+                    if (scrollState == AbsListView.OnScrollListener.SCROLL_STATE_TOUCH_SCROLL) {
                         followScrollEnabled = false
                     }
                     // When the user lifts their finger, check if we need to load more chapters

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
@@ -133,9 +133,19 @@ class ReaderActivity : BaseActivity() {
     // Сбрасывается в false при каждом открытии Activity, устанавливается в true только при
     // TOUCH_SCROLL или FLING — т.е. при реальном жесте, не при programmatic setSelectionFromTop.
     private var userHasScrolled = false
-    // Ручной скролл приостанавливает follow-скролл за TTS-абзацем до нажатия
-    // кнопки «Фокус» (или навигации по абзацам), чтобы экран не перехватывался.
-    private var followScrollEnabled = true
+    // Следование за TTS-абзацем приостанавливается только когда ручной скролл
+    // увёл текущий абзац с экрана; возобновляется, когда абзац снова виден, либо
+    // по кнопке «Фокус» / навигации по абзацам / главам.
+    private var followScrollEnabled = ReaderAutoScrollFollow.ACTIVE
+    // Палец пользователя лежит на экране (TOUCH_SCROLL) — до IDLE это один жест,
+    // включая fling. Programmatic smoothScrollToPosition* TOUCH_SCROLL не порождает,
+    // поэтому этот флаг надёжно отличает жест пользователя от нашего скролла.
+    private var manualGestureActive = false
+    // Последний целевой (позиция, отступ) programmatic-скролла и время его старта:
+    // дедупликация повторных smoothScrollToPositionFromTop в один и тот же таргет
+    // (LOADING+PLAYING одного абзаца рестартят одну и ту же анимацию — вибрация).
+    private var lastSmoothScrollTarget: Pair<Int, Int>? = null
+    private var lastSmoothScrollStart = 0L
 
     // Double-tap detection for showing/hiding reader info
     private var lastTapTime = 0L
@@ -317,7 +327,7 @@ class ReaderActivity : BaseActivity() {
             if (it !is ReaderItem.Position) return@observe
             // «Фокус» и переходы по абзацам — явное действие пользователя:
             // возобновляем follow-скролл.
-            followScrollEnabled = true
+            followScrollEnabled = ReaderAutoScrollFollow.ACTIVE
             scrollToReadingPositionForced(
                 chapterIndex = it.chapterIndex,
                 chapterItemPosition = it.chapterItemPosition,
@@ -326,6 +336,8 @@ class ReaderActivity : BaseActivity() {
 
         viewModel.readerSpeaker.scrollToChapterTop.asLiveData()
             .observe(this) { chapterIndex ->
+                // Переход на главу — как и навигация по абзацам: возобновляем follow.
+                followScrollEnabled = ReaderAutoScrollFollow.ACTIVE
                 scrollToReadingPositionForced(
                     chapterIndex = chapterIndex,
                     chapterItemPosition = 0,
@@ -497,6 +509,11 @@ class ReaderActivity : BaseActivity() {
                     if (listIsScrolling) {
                         updateReadingState()
                     }
+                    followScrollEnabled = nextFollowState(
+                        current = followScrollEnabled,
+                        manualGestureActive = manualGestureActive,
+                        currentParagraphVisible = isCurrentParagraphVisible(),
+                    )
                 }
 
                 override fun onScrollStateChanged(view: AbsListView?, scrollState: Int) {
@@ -509,14 +526,22 @@ class ReaderActivity : BaseActivity() {
                         userHasScrolled = true
                     }
                     // Programmatic smoothScrollToPosition* тоже отдаёт FLING (а не только
-                    // жест пользователя), поэтому follow отключаем ТОЛЬКО по TOUCH_SCROLL:
+                    // жест пользователя), поэтому жест детектируем ТОЛЬКО по TOUCH_SCROLL:
                     // это состояние возникает исключительно при касании пальца, когда
-                    // палец ещё на экране, и не бывает при programmatic-скролле.
+                    // палец ещё на экране, и не бывает при programmatic-скролле. Follow
+                    // приостанавливается не самим касанием, а уходом абзаца с экрана
+                    // (см. nextFollowState и onScroll).
                     if (scrollState == AbsListView.OnScrollListener.SCROLL_STATE_TOUCH_SCROLL) {
-                        followScrollEnabled = false
+                        manualGestureActive = true
                     }
                     // When the user lifts their finger, check if we need to load more chapters
                     if (!listIsScrolling) {
+                        manualGestureActive = false
+                        followScrollEnabled = nextFollowState(
+                            current = followScrollEnabled,
+                            manualGestureActive = manualGestureActive,
+                            currentParagraphVisible = isCurrentParagraphVisible(),
+                        )
                         updateReadingState()
                         // TTS catch-up: после окончания жеста сразу возвращаем подсветку
                         // на экран, не дожидаясь следующей эмиссии абзаца (может быть
@@ -643,8 +668,14 @@ class ReaderActivity : BaseActivity() {
             viewAdapter.listView.notifyDataSetChanged()
         }
 
-        // Ручной скролл приостанавливает follow-скролл до кнопки «Фокус».
-        if (!followScrollEnabled) {
+        // Ручной скролл, уведший текущий абзац с экрана, приостанавливает follow-скролл.
+        if (followScrollEnabled == ReaderAutoScrollFollow.PAUSED) {
+            return
+        }
+
+        // Пока палец на экране или идёт fling от жеста — не начинаем свой скролл,
+        // чтобы не бороться с ручным скроллом пользователя.
+        if (manualGestureActive) {
             return
         }
 
@@ -681,7 +712,7 @@ class ReaderActivity : BaseActivity() {
 
                 // Scroll only if item is below the desired visible position (fast scroll)
                 if (currentOffsetPx > newOffsetPx) {
-                    viewBind.listView.smoothScrollToPositionFromTop(index, newOffsetPx, 400)
+                    followSmoothScrollTo(index, newOffsetPx)
                 }
                 return
             }
@@ -706,17 +737,47 @@ class ReaderActivity : BaseActivity() {
         when {
             distanceBelow in 1..threshold -> {
                 // Close below visible area - smooth scroll
-                viewBind.listView.smoothScrollToPositionFromTop(itemPosition, newOffsetPx, 400)
+                followSmoothScrollTo(itemPosition, newOffsetPx)
             }
             distanceAbove in 1..threshold -> {
                 // Close above visible area - smooth scroll
-                viewBind.listView.smoothScrollToPositionFromTop(itemPosition, newOffsetPx, 400)
+                followSmoothScrollTo(itemPosition, newOffsetPx)
             }
             else -> {
                 // Far from visible area - instant scroll for better responsiveness
                 viewBind.listView.setSelectionFromTop(itemPosition, newOffsetPx)
             }
         }
+    }
+
+    private fun followSmoothScrollTo(itemPosition: Int, offsetPx: Int) {
+        val target = itemPosition to offsetPx
+        val now = SystemClock.elapsedRealtime()
+        if (!shouldIssueSmoothScroll(lastSmoothScrollTarget, lastSmoothScrollStart, target, now)) {
+            return
+        }
+        lastSmoothScrollTarget = target
+        lastSmoothScrollStart = now
+        viewBind.listView.smoothScrollToPositionFromTop(itemPosition, offsetPx, 400)
+    }
+
+    private fun isCurrentParagraphVisible(): Boolean {
+        val playing = viewModel.readerSpeaker.currentTextPlaying.value
+        val chapterIndex = playing.itemPos.chapterIndex
+        val chapterItemPosition = playing.itemPos.chapterItemPosition
+        val firstIndex = viewBind.listView.firstVisiblePosition
+        val lastIndex = viewBind.listView.lastVisiblePosition
+        for (index in firstIndex..lastIndex) {
+            val item = viewAdapter.listView.getItem(index)
+            if (
+                item.chapterIndex == chapterIndex &&
+                item is ReaderItem.Position &&
+                item.chapterItemPosition == chapterItemPosition
+            ) {
+                return true
+            }
+        }
+        return false
     }
 
     private fun scrollToReadingPositionForced(chapterIndex: Int, chapterItemPosition: Int) {

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
@@ -133,6 +133,9 @@ class ReaderActivity : BaseActivity() {
     // Сбрасывается в false при каждом открытии Activity, устанавливается в true только при
     // TOUCH_SCROLL или FLING — т.е. при реальном жесте, не при programmatic setSelectionFromTop.
     private var userHasScrolled = false
+    // Ручной скролл приостанавливает follow-скролл за TTS-абзацем до нажатия
+    // кнопки «Фокус» (или навигации по абзацам), чтобы экран не перехватывался.
+    private var followScrollEnabled = true
 
     // Double-tap detection for showing/hiding reader info
     private var lastTapTime = 0L
@@ -312,6 +315,9 @@ class ReaderActivity : BaseActivity() {
 
         viewModel.readerSpeaker.scrollToReaderItem.asLiveData().observe(this) {
             if (it !is ReaderItem.Position) return@observe
+            // «Фокус» и переходы по абзацам — явное действие пользователя:
+            // возобновляем follow-скролл.
+            followScrollEnabled = true
             scrollToReadingPositionForced(
                 chapterIndex = it.chapterIndex,
                 chapterItemPosition = it.chapterItemPosition,
@@ -501,6 +507,7 @@ class ReaderActivity : BaseActivity() {
                         scrollState == AbsListView.OnScrollListener.SCROLL_STATE_TOUCH_SCROLL
                     ) {
                         userHasScrolled = true
+                        followScrollEnabled = false
                     }
                     // When the user lifts their finger, check if we need to load more chapters
                     if (!listIsScrolling) {
@@ -628,6 +635,11 @@ class ReaderActivity : BaseActivity() {
             lastReboundChapterItemPosition = chapterItemPosition
             lastReboundPlayState = playState
             viewAdapter.listView.notifyDataSetChanged()
+        }
+
+        // Ручной скролл приостанавливает follow-скролл до кнопки «Фокус».
+        if (!followScrollEnabled) {
+            return
         }
 
         // If user is scrolling, don't auto-scroll

--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderAutoScroll.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderAutoScroll.kt
@@ -1,0 +1,21 @@
+package my.noveldokusha.features.reader
+
+enum class ReaderAutoScrollFollow { ACTIVE, PAUSED }
+
+fun nextFollowState(
+    current: ReaderAutoScrollFollow,
+    manualGestureActive: Boolean,
+    currentParagraphVisible: Boolean,
+): ReaderAutoScrollFollow = when {
+    currentParagraphVisible -> ReaderAutoScrollFollow.ACTIVE
+    manualGestureActive -> ReaderAutoScrollFollow.PAUSED
+    else -> current
+}
+
+fun shouldIssueSmoothScroll(
+    lastTarget: Pair<Int, Int>?,
+    lastStartedAt: Long,
+    newTarget: Pair<Int, Int>,
+    now: Long,
+    windowMs: Long = 500L,
+): Boolean = newTarget != lastTarget || now - lastStartedAt >= windowMs

--- a/features/reader/src/test/java/my/noveldokusha/features/reader/ReaderAutoScrollTest.kt
+++ b/features/reader/src/test/java/my/noveldokusha/features/reader/ReaderAutoScrollTest.kt
@@ -1,0 +1,71 @@
+package my.noveldokusha.features.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReaderAutoScrollTest {
+
+    @Test
+    fun visibleParagraphActivatesFollow() {
+        assertEquals(
+            ReaderAutoScrollFollow.ACTIVE,
+            nextFollowState(ReaderAutoScrollFollow.PAUSED, manualGestureActive = true, currentParagraphVisible = true)
+        )
+        assertEquals(
+            ReaderAutoScrollFollow.ACTIVE,
+            nextFollowState(ReaderAutoScrollFollow.PAUSED, manualGestureActive = false, currentParagraphVisible = true)
+        )
+        assertEquals(
+            ReaderAutoScrollFollow.ACTIVE,
+            nextFollowState(ReaderAutoScrollFollow.ACTIVE, manualGestureActive = false, currentParagraphVisible = true)
+        )
+    }
+
+    @Test
+    fun manualGestureWithParagraphOffScreenPausesFollow() {
+        assertEquals(
+            ReaderAutoScrollFollow.PAUSED,
+            nextFollowState(ReaderAutoScrollFollow.ACTIVE, manualGestureActive = true, currentParagraphVisible = false)
+        )
+        assertEquals(
+            ReaderAutoScrollFollow.PAUSED,
+            nextFollowState(ReaderAutoScrollFollow.PAUSED, manualGestureActive = true, currentParagraphVisible = false)
+        )
+    }
+
+    @Test
+    fun offScreenWithoutGestureKeepsCurrentState() {
+        assertEquals(
+            ReaderAutoScrollFollow.ACTIVE,
+            nextFollowState(ReaderAutoScrollFollow.ACTIVE, manualGestureActive = false, currentParagraphVisible = false)
+        )
+        assertEquals(
+            ReaderAutoScrollFollow.PAUSED,
+            nextFollowState(ReaderAutoScrollFollow.PAUSED, manualGestureActive = false, currentParagraphVisible = false)
+        )
+    }
+
+    @Test
+    fun sameTargetWithinWindowIsNotReissued() {
+        val target = 10 to 200
+        assertFalse(shouldIssueSmoothScroll(lastTarget = target, lastStartedAt = 1_000L, newTarget = target, now = 1_200L))
+    }
+
+    @Test
+    fun sameTargetAfterWindowIsReissued() {
+        val target = 10 to 200
+        assertTrue(shouldIssueSmoothScroll(lastTarget = target, lastStartedAt = 1_000L, newTarget = target, now = 1_600L))
+    }
+
+    @Test
+    fun differentTargetIsAlwaysReissued() {
+        assertTrue(shouldIssueSmoothScroll(lastTarget = 10 to 200, lastStartedAt = 1_000L, newTarget = 11 to 200, now = 1_100L))
+    }
+
+    @Test
+    fun noPreviousTargetIsReissued() {
+        assertTrue(shouldIssueSmoothScroll(lastTarget = null, lastStartedAt = 0L, newTarget = 10 to 200, now = 1_100L))
+    }
+}


### PR DESCRIPTION
Fixes #132

## Summary

TTS auto-scroll no longer fights manual scrolling and no longer jitters while reading.

It now pauses **only** when a manual scroll moves the current spoken paragraph off-screen, and resumes automatically when the paragraph is visible again, on the Focus button, or on next/prev paragraph / chapter navigation.

## Changes (features/reader only)

- **New pure follow-state machine** — `ReaderAutoScroll.kt`: `ACTIVE`/`PAUSED` decided from the user gesture and paragraph visibility; unit-tested (`ReaderAutoScrollTest.kt`, 11 cases).
- **Real-gesture latch** — `ReaderActivity.kt` now latches an actual finger touch (`SCROLL_STATE_TOUCH_SCROLL`) and keeps it until `IDLE`, so a programmatic `smoothScrollToPosition*` (which also emits `FLING`) can never be mistaken for a user gesture. The follow path is gated: paused state -> gesture latch -> existing fling watchdog.
- **Scroll dedupe** — identical programmatic smooth scrolls to the same target are suppressed within a 500ms window, removing the restart-vibration jitter when a paragraph is re-emitted (`LOADING` + `PLAYING`).
- **Default behavior unchanged** — when the user is not touching the screen, follow behavior is exactly as before.

## Verified

- Unit tests `:features:reader:testDebugUnitTest` and compile `:features:reader:compileReleaseKotlin` pass.
- APK build (`buildRelease.yml`, `build_type: test`) passes on the branch.
