### PR TITLE
fix(reader): respect manual scroll during TTS playback

### DIFF
--- a/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
+++ b/features/reader/src/main/java/my/noveldokusha/features/reader/ReaderActivity.kt
@@ -160,6 +160,11 @@ class ReaderActivity : BaseActivity() {
     // Пауза по касанию/жизненному циклу: любой тач по списку останавливает скролл.
     private var autoScrollPaused = false
 
+    // When true, TTS follow-along skips snap-back to off-screen paragraphs.
+    // Set when user manually scrolls away from the current paragraph.
+    // Reset on: Focus, Next/Prev paragraph, paragraph becomes visible, onResume.
+    private var userManualScrollActive = false
+
     // Double-tap detection for showing/hiding reader info
     private var lastTapTime = 0L
     private val doubleTapThresholdMs = 350L
@@ -616,6 +621,18 @@ class ReaderActivity : BaseActivity() {
                         // не делает, если текущий абзац уже видим.
                         if (viewModel.readerSpeaker.isSpeaking.value) {
                             val playing = viewModel.readerSpeaker.currentTextPlaying.value
+                            // If user manually scrolled away from current paragraph,
+                            // activate the flag to prevent snap-back on subsequent
+                            // paragraph changes (currentReaderItem observer).
+                            if (!userManualScrollActive) {
+                                if (!isTtsParagraphVisible(
+                                        playing.itemPos.chapterIndex,
+                                        playing.itemPos.chapterItemPosition
+                                    )
+                                ) {
+                                    userManualScrollActive = true
+                                }
+                            }
                             scrollToReadingPositionOptional(
                                 chapterIndex = playing.itemPos.chapterIndex,
                                 chapterItemPosition = playing.itemPos.chapterItemPosition,
@@ -779,6 +796,16 @@ class ReaderActivity : BaseActivity() {
             }
         }
 
+        // User manually scrolled away from current paragraph — don't snap back.
+        // Resume when: paragraph becomes visible again, Focus, or Next/Prev paragraph.
+        if (userManualScrollActive) {
+            if (isTtsParagraphVisible(chapterIndex, chapterItemPosition)) {
+                userManualScrollActive = false
+            } else {
+                return
+            }
+        }
+
         // Check if the TTS item is already visible on screen
         val firstIndex = viewBind.listView.firstVisiblePosition
         val lastIndex = viewBind.listView.lastVisiblePosition
@@ -836,6 +863,8 @@ class ReaderActivity : BaseActivity() {
     }
 
     private fun scrollToReadingPositionForced(chapterIndex: Int, chapterItemPosition: Int) {
+        // Explicit user action (Focus / Next / Prev) — resume follow-along
+        userManualScrollActive = false
         // Search for the item being read otherwise do nothing
         val itemIndex = indexOfReaderItem(
             list = viewModel.items,
@@ -850,6 +879,8 @@ class ReaderActivity : BaseActivity() {
     }
 
     private fun scrollToReadingPositionImmediately(chapterIndex: Int, chapterItemPosition: Int) {
+        // Explicit focus action — resume follow-along
+        userManualScrollActive = false
         // Search for the item being read otherwise do nothing
         val itemIndex = indexOfReaderItem(
             list = viewModel.items,
@@ -892,6 +923,25 @@ class ReaderActivity : BaseActivity() {
             (listView.firstVisiblePosition + listView.childCount - 1)
                 .coerceAtMost(viewAdapter.listView.count - 1)
         )
+    }
+
+    /**
+     * Checks if the given TTS paragraph is currently visible in the viewport.
+     * Used by userManualScrollActive logic to decide whether to snap back or resume.
+     */
+    private fun isTtsParagraphVisible(chapterIndex: Int, chapterItemPosition: Int): Boolean {
+        val firstIndex = viewBind.listView.firstVisiblePosition
+        val lastIndex = viewBind.listView.lastVisiblePosition
+        for (index in firstIndex..lastIndex) {
+            val item = viewAdapter.listView.getItem(index)
+            if (item.chapterIndex == chapterIndex &&
+                item is ReaderItem.Position &&
+                item.chapterItemPosition == chapterItemPosition
+            ) {
+                return true
+            }
+        }
+        return false
     }
 
     private fun updateReadingState() {
@@ -993,6 +1043,9 @@ class ReaderActivity : BaseActivity() {
 
     override fun onResume() {
         super.onResume()
+
+        // Resume follow-along: user returned to the app, existing code scrolls to TTS position.
+        userManualScrollActive = false
 
         // Возобновляем автопрокрутку после возврата на экран, если она включена.
         if (appPreferences.READER_AUTOSCROLL_ENABLED.value) {


### PR DESCRIPTION
## What

Respect manual scroll during TTS playback — when you scroll to read ahead, the screen no longer snaps back to the current paragraph.

## Why

`scrollToReadingPositionOptional()` fires on every paragraph change and on every scroll-idle event. Both paths force-scroll to the current paragraph when it is off-screen, even when the user intentionally scrolled away to read ahead. This makes it impossible to browse the text while listening.

## How

Added a `userManualScrollActive` flag to `ReaderActivity.kt`:

- **Sets** when the user lifts their finger and the current TTS paragraph is off-screen
- **Blocks** snap-back to off-screen paragraphs — highlighting still updates instantly
- **Resets** automatically when the paragraph becomes visible, the user taps Focus/Next/Prev, or the app resumes from background

No changes to TTS engine, playback, or highlighting logic. Only the scroll-follow behavior is affected.

## Behavior

| User action | Before | After |
|---|---|---|
| Scroll away while TTS plays | Snaps back on finger lift | Stays where you scrolled |
| Tap Focus | Scrolls to paragraph | Same |
| Tap Next/Prev | Scrolls to paragraph | Same |
| TTS reaches a visible paragraph | Follows | Follows (auto-resumes) |
| Return from background | Scrolls to paragraph | Same |
| No TTS active | Normal scrolling | No change |

## Test

1. Open a chapter, start TTS
2. While TTS reads, scroll down to read ahead
3. Lift finger — screen stays where you scrolled
4. Tap Focus — screen jumps to current paragraph
5. Tap Next/Prev — screen follows to the new paragraph
6. Verify TTS highlighting updates even while scrolled away
